### PR TITLE
save memory by removing stiffness matrices attributes from CBL connector class

### DIFF
--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -51,9 +51,6 @@ ChElementCBLCON::ChElementCBLCON()
       use_geometric_stiffness(false)
 {
     nodes.resize(2);
-
-    Km.setZero(this->GetNumCoordsPosLevel(), this->GetNumCoordsPosLevel());
-    Kg.setZero(this->GetNumCoordsPosLevel(), this->GetNumCoordsPosLevel());
 }
 
 void ChElementCBLCON::SetNodes(std::shared_ptr<ChNodeFEAxyzrot> nodeA, std::shared_ptr<ChNodeFEAxyzrot> nodeB) {
@@ -383,9 +380,8 @@ void ChElementCBLCON::ComputeMmatrixGlobal(ChMatrixRef M) {
 
 
 
-void ChElementCBLCON::ComputeStiffnessMatrix() {
+void ChElementCBLCON::ComputeStiffnessMatrixGlobal(ChMatrixRef Km) {
         assert(section);
-        Km.resize(12,12);
 
         double normal_stiff = this->section->Get_material()->Get_E0() * this->section->Get_area() / this->length;
         double tangent_stiff = normal_stiff * this->section->Get_material()->Get_alpha();
@@ -478,8 +474,9 @@ void ChElementCBLCON::ComputeStiffnessMatrix() {
 }
 
 
-void ChElementCBLCON::ComputeGeometricStiffnessMatrix() {
+void ChElementCBLCON::ComputeGeometricStiffnessMatrixGlobal(ChMatrixRef Kg) {
     assert(section);
+    // Geometric stiffness matrix not implemented
 
 }
 
@@ -519,15 +516,6 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
             this->section->ComputeProjectionMatrix();
             this->section->ComputeEigenStrain(this->macro_strain);
     }
-
-    //
-    // Compute local stiffness matrix:
-    //
-    ComputeStiffnessMatrix();
-    //
-    // Compute local geometric stiffness matrix normalized by pull force P: Kg/P
-    //
-    ComputeGeometricStiffnessMatrix();
 }
 
 void ChElementCBLCON::ComputeKRMmatricesGlobal(ChMatrixRef H, double Kfactor, double Rfactor, double Mfactor) {
@@ -546,39 +534,17 @@ void ChElementCBLCON::ComputeKRMmatricesGlobal(ChMatrixRef H, double Kfactor, do
             //           not being reset when calling this->ComputeInternalForces
         }
         else {
-
-            // K stiffness:
-
-
-
-            ChMatrixDynamic<> H_local;
-
+            // CBL currently uses the initial elastic stiffness matrix
+            ChMatrixNM<double, 12, 12> Km;
+            ComputeStiffnessMatrixGlobal(Km);
 
             if (this->use_geometric_stiffness) {
-                // K = Km+Kg
-
-                // For Kg, compute Px tension of the beam along centerline, using temporary but fast data structures:
-                ChVectorDynamic<> displ(this->GetNumCoordsPosLevel());
-                this->GetStateBlock(displ);
-                double Px = -this->Km.row(0) * displ;
-
-                // Rayleigh damping (stiffness proportional part)  [R] = beta*[Km] , so H = kf*[Km+Kg]+rf*[R] = (kf+rf*beta)*[Km] + kf*Kg
-                //H_local = this->Km * (Kfactor + Rfactor * this->section->GetBeamRaleyghDampingBeta()) + this->Kg * Px * Kfactor;
-        H_local = this->Km * ( Kfactor ) + this->Kg * Px * Kfactor;
+                ChMatrixNM<double, 12, 12> Kg;
+                ComputeGeometricStiffnessMatrixGlobal(Kg); // TODO: not currently implemented
+                H.block(0, 0, 12, 12) = (Km + Kg) * Kfactor;
+            } else {
+                H.block(0, 0, 12, 12) = Km * Kfactor;
             }
-            else {
-                // K = Km
-
-                // Rayleigh damping (stiffness proportional part)  [R] = beta*[Km] , so H = kf*[Km]+rf*[R] = (kf+rf*beta)*[K]
-                //H_local = this->Km * (Kfactor + Rfactor * this->section->GetBeamRaleyghDampingBeta());
-        H_local = this->Km * Kfactor;
-
-            }
-
-            //H.block(0, 0, 12, 12) = CKCt;
-
-        H.block(0, 0, 12, 12) = H_local;
-
         }
 
     }

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -540,97 +540,10 @@ void ChElementCBLCON::ComputeKRMmatricesGlobal(ChMatrixRef H, double Kfactor, do
     if (Kfactor || Rfactor) {
 
         if (use_numerical_diff_for_KR) {
-        //std::cout<<"////////////////////////////////////////////////////////\n";
-            // numerical evaluation of the K R  matrices
-            double delta_p = 1e-5;
-            double delta_r = 1e-3;
-
-            ChVectorDynamic<> Fi0(12);
-            ChVectorDynamic<> FiD(12);
-            this->ComputeInternalForces(Fi0);
-            ChMatrixDynamic<> H_num(12, 12);
-
-            // K
-            ChVector3d     pa0 = this->GetNodeA()->GetPos();
-            ChQuaternion<> qa0 = this->GetNodeA()->GetRot();
-            ChVector3d     pb0 = this->GetNodeB()->GetPos();
-            ChQuaternion<> qb0 = this->GetNodeB()->GetRot();
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d paD = pa0;
-                paD[i] += delta_p;
-                this->GetNodeA()->SetPos(paD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i) = (FiD - Fi0) / delta_p;
-                this->GetNodeA()->SetPos(pa0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d rotator(VNULL);  rotator[i] = delta_r;
-                ChQuaternion<> mdeltarotL;  mdeltarotL.SetFromRotVec(rotator); // rot.in local basis - as in system wide vectors
-                ChQuaternion<> qaD = qa0 * mdeltarotL;
-                this->GetNodeA()->SetRot(qaD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+3) = (FiD - Fi0) / delta_r;
-                this->GetNodeA()->SetRot(qa0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d pbD = pb0;
-                pbD[i] += delta_p;
-                this->GetNodeB()->SetPos(pbD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+6) = (FiD - Fi0) / delta_p;
-                this->GetNodeB()->SetPos(pb0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d rotator(VNULL);  rotator[i] = delta_r;
-                ChQuaternion<> mdeltarotL;  mdeltarotL.SetFromRotVec(rotator); // rot.in local basis - as in system wide vectors
-                ChQuaternion<> qbD = qb0 * mdeltarotL;
-                this->GetNodeB()->SetRot(qbD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+9) = (FiD - Fi0) / delta_r;
-                this->GetNodeB()->SetRot(qb0);
-            }
-            H.block(0, 0, 12, 12) =  -H_num * Kfactor;
-            //exit(2);
-            /*
-            // R
-            ChVector3d va0 = this->GetNodeA()->GetPosDt();
-            ChVector3d wa0 = this->GetNodeA()->GetAngVelLocal();
-            ChVector3d vb0 = this->GetNodeB()->GetPosDt();
-            ChVector3d wb0 = this->GetNodeB()->GetAngVelLocal();
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d vaD = va0;
-                vaD[i] += delta_p;
-                this->GetNodeA()->SetPos_dt(vaD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i) = (FiD - Fi0) / delta_p;
-                this->GetNodeA()->SetPos_dt(va0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d waD = wa0;
-                waD[i] += delta_r;
-                this->GetNodeA()->SetWvel_loc(waD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+3) = (FiD - Fi0) / delta_r;
-                this->GetNodeA()->SetWvel_loc(wa0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d vbD = vb0;
-                vbD[i] += delta_p;
-                this->GetNodeB()->SetPos_dt(vbD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+6) = (FiD - Fi0) / delta_p;
-                this->GetNodeB()->SetPos_dt(vb0);
-            }
-            for (int i = 0; i < 3; ++i) {
-                ChVector3d wbD = wb0;
-                wbD[i] += delta_r;
-                this->GetNodeB()->SetWvel_loc(wbD);
-                this->ComputeInternalForces(FiD);
-                H_num.block<12,1>(0, i+9) = (FiD - Fi0) / delta_r;
-                this->GetNodeB()->SetWvel_loc(wb0);
-            }
-            H.block(0, 0, 12, 12) += - H_num * Rfactor;
-        */
+            // TODO JBC: numerical differentiation not used for this elements / material
+            //           I think the previous code that was copy-pasted here was wrong
+            //           with the current implementation of CBL due to displacement update
+            //           not being reset when calling this->ComputeInternalForces
         }
         else {
 

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -162,20 +162,12 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 	///
 	///	
 	virtual void ComputeMmatrixGlobal(ChMatrixRef M) override;
-    /// Computes the local (material) stiffness matrix of the element:
-    /// K = integral( [B]' * [D] * [B] ),
-    /// Note: in this 'basic' implementation, constant section and
-    /// constant material are assumed, so the explicit result of quadrature is used.
-    /// Also, this local material stiffness matrix is constant, computed only at the beginning 
-    /// for performance reasons; if you later change some material property, call this or InitialSetup().
-    void ComputeStiffnessMatrix();
 
-    /// Computes the local geometric stiffness Kg of the element.
-    /// Note: this->Kg will be set as the geometric stiffness EXCLUDING the multiplication by the P pull force,
-    /// in fact P multiplication happens in all terms, thus this allows making the Kg as a constant matrix that
-    /// is computed only at the beginning, and later it is multiplied by P all times the real Kg is needed.
-    /// If you later change some material property, call this or InitialSetup().
-    void ComputeGeometricStiffnessMatrix();
+    /// Computes the global stiffness matrix of the element:
+    void ComputeStiffnessMatrixGlobal(ChMatrixRef Km);
+
+    /// Computes the global geometric stiffness Kg of the element.
+    void ComputeGeometricStiffnessMatrixGlobal(ChMatrixRef Kg);
 
     /// Sets H as the global stiffness matrix K, scaled  by Kfactor. Optionally, also
     /// superimposes global damping matrix R, scaled by Rfactor, and global mass matrix M multiplied by Mfactor.
@@ -323,8 +315,6 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 
     std::shared_ptr<ChBeamSectionCBLCON> section;
 
-    ChMatrixDynamic<> Km;  ///< local material  stiffness matrix
-    ChMatrixDynamic<> Kg;  ///< local geometric stiffness matrix NORMALIZED by P
 
     ChQuaternion<> q_refrotA;
     ChQuaternion<> q_refrotB;

--- a/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
@@ -250,7 +250,8 @@ TEST(CBLConnectorTest, elastic_stiffness_matrix){
     sys.DoStepDynamics(0);
 
     // Chrono-CBL calculation of the stiffness matrix
-    connector->ComputeStiffnessMatrix();
+    ChMatrixNM<double, 12, 12> CBLCON_matrix;
+    connector->ComputeStiffnessMatrixGlobal(CBLCON_matrix);
 
 
     // Analytical calculation of the stiffness matrix
@@ -307,7 +308,7 @@ TEST(CBLConnectorTest, elastic_stiffness_matrix){
 
     for (int i = 0; i < 12; i++){
         for (int j = 0 ; j < 12 ; j++) {
-            ASSERT_NEAR(connector->Km(i, j), analytical_matrix(i, j), tol);
+            ASSERT_NEAR(CBLCON_matrix(i, j), analytical_matrix(i, j), tol);
         }
     }
 }


### PR DESCRIPTION
This PR deletes the stiffness and geometric stiffness matrices from the `ChElementCBLCON` elements to save memory as discussed in #14 .

Matrices `Km` and `Kg` were stored as attributes of the `ChElementCBLCON` class, then copied into the `KRMblock` matrix inside the `ChElementCBLCON::ComputeKRMmatricesGlobal()` function whenever Chrono needs this.

So the content of these matrices is stored twice in memory. Deleting them saves two 12x12 matrices of type double, i.e., `2*12*12*8=2.304` kB per connector, which adds up to 1.1 GB for 500,000 connectors.