### PR TITLE
cleanup unused LDPM code from CBL connector material behavior

### DIFF
--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -753,16 +753,15 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     StateVarVector statev;
     this->ComputeStrainIncrement(dofs_increment, dmstrain, dcurvature);
     statev=mysection->Get_StateVar();
-    double epsV=0; // TODO JBC: Volumetric strain seems to be a remnant of LDPM. remove it when refactoring ComputeStress
     double width=mysection->GetWidth()/2;
     double height=mysection->GetHeight()/2;
     double random_field =mysection->GetRandomField();
 
     auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
     if (nonMechanicalStrain.size()){
-        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, nonMechanicalStrain, length, epsV, statev, area, width, height, random_field, mstress, mcouple);
+        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
     }else{
-        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, length, epsV, statev, area, width, height, random_field, mstress, mcouple);
+        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, length, statev, area, width, height, random_field, mstress, mcouple);
     }
 
     mysection->Set_StateVar(statev);

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,7 +49,7 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature,double &len, double &epsV, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature,double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
     	ChVector3d mstrain;
     	ChVector3d mcurvature;	
 	//
@@ -324,7 +324,7 @@ void ChWoodMaterialVECT::ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& 
 }
 */
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature, ChVectorDynamic<>& eigenstrain ,double &len, double &epsV, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature, ChVectorDynamic<>& eigenstrain ,double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
     	ChVector3d mstrain;
     	ChVector3d mcurvature;	
 	//

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -28,34 +28,13 @@ namespace wood {
 ChWoodMaterialVECT::ChWoodMaterialVECT(double rho,  // material density
                                        double E0,    // Mesoscale Young's modulus
                                        double alpha,   // Mesoscale Poisson ratio                                       
-                                       double sigmat, double sigmas, double nt, double lt, 
-									   double Ed, double sigmac0, double beta, double Hc0,
-									   double Hc1, double kc0, double kc1, double kc2, double kc3,
-									   double mu0, double muinf, double sigmaN0, double kt)
-    : m_rho(rho), m_E0(E0), m_alpha(alpha), m_sigmat(sigmat), m_sigmas(sigmas), m_nt(nt),
-		m_lt(lt), m_Ed(Ed), m_sigmac0(sigmac0), m_beta(beta), m_Hc0(Hc0), m_Hc1(Hc1),
-		m_kc0(kc0), m_kc1(kc1), m_kc2(kc2), m_kc3(kc3), m_mu0(mu0), m_muinf(muinf), 
-		m_sigmaN0(sigmaN0), m_kt(kt) {
-        
-}
+                                       double sigmat, double sigmac, double sigmas,
+                                       double nt, double lt, double rs)
+    : m_rho(rho), m_E0(E0), m_alpha(alpha), m_sigmat(sigmat), m_sigmas(sigmas), m_sigmac(sigmac), m_nt(nt), m_lt(lt), m_rs(rs) {}
 
+ChWoodMaterialVECT::ChWoodMaterialVECT() {}
 
-ChWoodMaterialVECT::ChWoodMaterialVECT(){
-    /*double m_rho=2.4E-9;
-    double m_E0=30000;
-    double m_alpha=0.2;*/
-};
-
-/*
-// Copy constructor
-ChWoodMaterialVECT::ChWoodMaterialVECT(const ChWoodMaterialVECT& my_material)
-	: m_rho(my_material.m_rho), m_E0(my_material.m_E0),
-		m_alpha(my_material.m_alpha)
-{};
-*/
-
-// Destructor
-ChWoodMaterialVECT::~ChWoodMaterialVECT()	{};
+ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 
 // statec(0): normal N strain
 // statec(1): shear M strain
@@ -77,7 +56,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 	double E0=this->Get_E0();
 	double alpha=this->Get_alpha();	
 	double sigmat = this->Get_sigmat();	
-	double sigmac = this->Get_sigmac0();
+	double sigmac = this->Get_sigmac();
 	if (random_field)
 		E0=E0*random_field;
 	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
@@ -147,30 +126,6 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 				 mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
 				 mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
 			 }
-			 
-			 /*
-			 //CompressBC(mstrain, epsV, statev);
-			std::vector<double> sigmaT = ShearBC(mstrain, mcurvature, (w2+h2)/3, statev);
-			double sigmaM = sigmaT[0];
-			double sigmaL = sigmaT[1];
-			double coupleN = sigmaT[2];
-						
-			mstress[0]=statev(3)+(mstrain[0]-statev(0))*E0;
-			mstress[1]=sigmaM;
-			mstress[2]=sigmaL;
-			if(this->GetCoupleMultiplier()){
-				double multiplier=this->GetCoupleMultiplier()/3.;
-				mcouple[0]=coupleN;
-				//mcouple[1]=multiplier*sigmaN*mcurvature[1]*w2/epsQN;
-				//mcouple[2]=multiplier*sigmaN*mcurvature[2]*h2/epsQN;	
-				////
-				//mcouple[0]=multiplier*alpha*mcurvature[0]*(w2+h2)*E0;
-				//mcouple[1]=multiplier*mcurvature[1]*w2*E0;
-				//mcouple[2]=multiplier*mcurvature[2]*h2*E0;
-				mcouple[1]=statev(16)+multiplier*(mcurvature[1] - statev(13))*w2*E0;
-				mcouple[2]=statev(17)+multiplier*(mcurvature[2] - statev(14))*h2*E0;
-			}
-			*/
 		}
 		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
 		double w_N = len * (mstrain[0] - mstress[0] / E0);
@@ -443,33 +398,6 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 				 mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
 				 mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
 			 }
-			 
-			 /*
-			 //CompressBC(mstrain, epsV, statev);
-			std::vector<double> sigmaT = ShearBC(mstrain, mcurvature, (w2+h2)/3, statev);
-			double sigmaM = sigmaT[0];
-			double sigmaL = sigmaT[1];
-			double coupleN = sigmaT[2];
-						
-			//mstress[0]=statev(3)+(mstrain[0]-statev(0))*E0;
-			mstress[0]=statev(3)+dmstrain[0]*E0;
-			mstress[1]=sigmaM;
-			mstress[2]=sigmaL;
-			if(this->GetCoupleMultiplier()){
-				double multiplier=this->GetCoupleMultiplier()/3.;
-				mcouple[0]=coupleN;
-				//mcouple[1]=multiplier*sigmaN*mcurvature[1]*w2/epsQN;
-				//mcouple[2]=multiplier*sigmaN*mcurvature[2]*h2/epsQN;	
-				////
-				//mcouple[0]=multiplier*alpha*mcurvature[0]*(w2+h2)*E0;
-				//mcouple[1]=multiplier*mcurvature[1]*w2*E0;
-				//mcouple[2]=multiplier*mcurvature[2]*h2*E0;
-				//mcouple[1]=statev(16)+multiplier*(mcurvature[1] - statev(13))*w2*E0;
-				//mcouple[2]=statev(17)+multiplier*(mcurvature[2] - statev(14))*h2*E0;
-				mcouple[1]=statev(16)+multiplier*dmcurvature[1] * w2*E0;
-				mcouple[2]=statev(17)+multiplier*dmcurvature[2] * h2*E0;
-			}
-			*/
 		}
 		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
 		double w_N = len * (mstrain[0] - mstress[0] / E0);
@@ -583,10 +511,9 @@ double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field,
 	double alpha = this->Get_alpha();
 	double sigmat = this->Get_sigmat();
 	double sigmas = this->Get_sigmas();
-	double sigmac0 = this->Get_sigmac0();
+	double sigmac = this->Get_sigmac();
 	double nt = this->Get_nt();   
 	double lt = this->Get_lt();
-	double kt = this->Get_kt();
 	if (random_field)
 		sigmat=sigmat*random_field;
 	//double Gt = this->Get_Gt();
@@ -633,38 +560,18 @@ double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field,
 	double alpha = this->Get_alpha();
 	double sigmat = this->Get_sigmat();
 	double sigmas = this->Get_sigmas();
-	double sigmac0 = this->Get_sigmac0();
-	double beta = this->Get_beta();
+	double sigmac = this->Get_sigmac();
 	double nt = this->Get_nt();   
 	double lt = this->Get_lt();
-	double kt = this->Get_kt();
 	if (random_field)
 		sigmat=sigmat*random_field;
-	// compression BC
-	/*double Ed = this->Get_Ed();
-	double Hc0 = this->Get_Hc0();
-	double Hc1 = this->Get_Hc1();
-	double kc0 = this->Get_kc0();
-	double kc1 = this->Get_kc1();
-	double kc2 = this->Get_kc2();*/
-	
-	//Shear BC
-	/*double mu0 = this->Get_mu0();
-	double muinf = this->Get_muinf();
-	double sigmaN0 = this->Get_sigmaN0();
-	double multiplier=this->GetCoupleMultiplier();*/
-
-	//double Gt = this->Get_Gt();
-	//
-	//double epsQ = pow(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]), 0.5);
-	//double epsT = pow(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2], 0.5);
 
 	// calculate stress boudary sigma_bt for tension
 	double omega, sinw, cosw, cosw2, beta2, sigma0;
 	
 	omega = atan(-epsQN / (pow(alpha, 0.5) * epsT));
 	
-	beta2 = (sigmas * sigmas) / (sigmac0 * sigmac0);
+	beta2 = (sigmas * sigmas) / (sigmac * sigmac);
 
 	sinw = sin(omega);
 	cosw = cos(omega);
@@ -673,10 +580,10 @@ double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field,
 
 	//if (omega <= 0) {  
 		//omega = CH_PI * 0.5;
-		//sigma0 = sigmac0;
+		//sigma0 = sigmac;
 	//}
 	//else {
-	sigma0 = sigmac0 / sqrt((sinw * sinw + (alpha * cosw2) / beta2));
+	sigma0 = sigmac / sqrt((sinw * sinw + (alpha * cosw2) / beta2));
 	//}
 
 	double eps0 = sigma0 / E0;
@@ -694,143 +601,6 @@ double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field,
 	//std::cout<<"epsQ: "<<epsQ<<" epsQ_0: "<<statev(8)<<" sigma_0: "<<statev(9)<<" strs_ela: "<<strs_ela<<"\tsigma_bt: "<<sigma_bt<<"\tsigma_fr: "<<sigma_fr<<std::endl;
 	//exit(9);
 	return sigma_fr;
-}
-
-
-/*
-double ChWoodMaterialVECT::CompressBC(ChVectorDynamic<>& mstrain, double& epsV, ChVectorDynamic<>& statev) {
-	double E0 = this->Get_E0();
-	double Ed = this->Get_Ed();
-	double sigmac0 = this->Get_sigmac0();
-	double beta = this->Get_beta();
-	double Hc0 = this->Get_Hc0();
-	double Hc1 = this->Get_Hc1();
-	double kc0 = this->Get_kc0();
-	double kc1 = this->Get_kc1();
-	double kc2 = this->Get_kc2();
-	double kc3 = this->Get_kc3();
-
-	double epsD = mstrain[0] - epsV;
-	double epsDV = epsV + beta * epsD;
-	double epsc0 = sigmac0 / E0;
-	double epsc1 = epsc0 * kc0;
-	double epsv0 = epsc0 * kc3;
-
-	//std::cout << "epsV " << epsV << std::endl;
-
-	double r_DV;
-	if (epsV <= 0) {
-		r_DV = -abs(epsD) / (epsV - epsv0);
-	}
-	else {
-		r_DV = abs(epsD) / epsv0;
-	}
-
-	double Hc = (Hc0 - Hc1) / (1 + kc2 * std::max(r_DV - kc1, 0.0)) + Hc1;
-	double sigmac1 = sigmac0 + (epsc1 - epsc0) * Hc;
-
-	double sigma_bc;
-	if (-epsDV <= 0) {
-		sigma_bc = sigmac0;
-	}
-	else if (-epsDV > 0 && -epsDV <= epsc1) {
-		sigma_bc = sigmac0 + std::max((-epsDV - epsc0), 0.0) * Hc;
-		//std::cout << "case2 "  << std::endl;
-	}
-	else {
-		sigma_bc = sigmac1 * exp((-epsDV - epsc1) * Hc / sigmac1);
-		//std::cout << "case3 " << std::endl;
-	}
-
-	//std::cout << "epsDV " << epsDV << std::endl;
-	//std::cout << "Hc " << Hc << std::endl;
-	//std::cout << "epsc1 " << epsc1 << std::endl;
-
-	double ENc;
-	if (-statev(3) < sigmac0) {
-		ENc = E0;
-	}
-	else {
-		ENc = Ed;
-	}
-
-	double sigma_ela = statev(3) + ENc * (mstrain[0] - statev(0));
-	double sigma_com = std::min(std::max(sigma_ela, -sigma_bc), 0.0);
-	return sigma_com;
-}
-*/
-
-
-
-std::pair<double, double> ChWoodMaterialVECT::ShearBC(ChVector3d& mstrain, StateVarVector& statev) {
-	double E0 = this->Get_E0();
-	double alpha = this->Get_alpha();
-	double mu0 = this->Get_mu0();
-	double muinf = this->Get_muinf();
-	double sigmas = this->Get_sigmas();
-	double sigmaN0 = this->Get_sigmaN0();
-
-	double sigmabs = sigmas + (mu0 - muinf) * sigmaN0 - muinf * statev(3) - (mu0 - muinf) * sigmaN0 * exp(statev(3) / sigmaN0);
-	//double sigmabs = sigmas - muinf * statev(3);
-	
-	double ET = alpha * E0;
-	double sigmaM_ela = statev(4) + (mstrain[1] - statev(1)) * ET;
-	double sigmaL_ela = statev(5) + (mstrain[2] - statev(2)) * ET;
-	double sigmaT_ela = std::sqrt(sigmaM_ela * sigmaM_ela + sigmaL_ela * sigmaL_ela);
-
-	double sigmaT = std::min(std::max(sigmaT_ela, 0.0), sigmabs);
-
-	double sigmaM, sigmaL;
-
-	if (sigmaT_ela != 0) {
-		sigmaM = sigmaT * sigmaM_ela / sigmaT_ela;
-		sigmaL = sigmaT * sigmaL_ela / sigmaT_ela;
-	}
-	else {
-		sigmaM = 0;
-		sigmaL = 0;
-	}
-	
-	return std::make_pair(sigmaM, sigmaL);
-}
-
-
-
-std::vector<double> ChWoodMaterialVECT::ShearBC(ChVector3d& mstrain, ChVector3d& mcurvature, double rN2, StateVarVector& statev) {
-	double E0 = this->Get_E0();
-	double alpha = this->Get_alpha();
-	double mu0 = this->Get_mu0();
-	double muinf = this->Get_muinf();
-	double sigmas = this->Get_sigmas();
-	double sigmaN0 = this->Get_sigmaN0();
-	double multiplier=this->GetCoupleMultiplier();
-
-	//double sigmabs = sigmas + (mu0 - muinf) * sigmaN0 - muinf * statev(3) - (mu0 - muinf) * sigmaN0 * exp(statev(3) / sigmaN0);
-	double sigmabs = sigmas - mu0 * statev(3);
-	
-	double ET = alpha * E0;
-	double sigmaM_ela = statev(4) + (mstrain[1] - statev(1)) * ET;
-	double sigmaL_ela = statev(5) + (mstrain[2] - statev(2)) * ET;
-	double coupleN_ela = statev(15) + multiplier*(mcurvature[0] - statev(12)) * rN2* ET;	
-	double sigmaT_ela = std::sqrt(sigmaM_ela * sigmaM_ela + sigmaL_ela * sigmaL_ela + coupleN_ela* coupleN_ela/rN2/multiplier);
-
-	double sigmaT = std::min(std::max(sigmaT_ela, 0.0), sigmabs);
-	//std::cout<<"sigmaM_ela: "<<sigmaM_ela<<"  sigmaL_ela: "<<sigmaL_ela<<" coupleN_ela: "<<coupleN_ela<< std::endl;
-	//std::cout<<"sigmaT: "<<sigmaT<<"  sigmaT_ela: "<<sigmaT_ela<<std::endl;
-	double sigmaM, sigmaL, coupleN;
-
-	if (sigmaT_ela != 0) {
-		sigmaM = sigmaT * sigmaM_ela / sigmaT_ela;
-		sigmaL = sigmaT * sigmaL_ela / sigmaT_ela;
-		coupleN = sigmaT * coupleN_ela  / sigmaT_ela;
-	}
-	else {
-		sigmaM = 0;
-		sigmaL = 0;
-		coupleN = 0;
-	}
-	
-	return {sigmaM, sigmaL, coupleN}; //std::make_pair(sigmaM, sigmaL);
 }
 
 

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -128,7 +128,7 @@ class ChWoodApi ChWoodMaterialVECT {
     double m_rs;                ///< shear softening modulus ratio
     double RayleighDampingK=0;
     double RayleighDampingM=0;
-    double mcouple_mult=0;
+    double mcouple_mult=0; ///<  influence factor for rotational DOF: beta_N = beta_M = beta_B
 	bool m_ElasticAnalysis=false;
 	bool m_CoupleContrib2EquStrain=false;
   //public:

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -105,14 +105,13 @@ class ChWoodApi ChWoodMaterialVECT {
     double GetCoupleContrib2EquStrainFlag() const { return m_CoupleContrib2EquStrain; }
     void SetCoupleContrib2EquStrainFlag(double CoupleContrib2EquStrain) { m_CoupleContrib2EquStrain = CoupleContrib2EquStrain; }	
     /// Compute stresses from given strains and state variables.
-    void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, double &len, double& epsV, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+    void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     //void ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& curvature_incr, double &length, StateVarVector& statev, double& width, double& height, double& random_field, ChVector3d& stress, ChVector3d& surfacic_couple);
     //
-	void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, ChVectorDynamic<>& eigenstrain, double &len, double& epsV, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+	void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, ChVectorDynamic<>& eigenstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     
     double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev);
 
-    //double CompressBC(ChVectorDynamic<>& mstrain, double& epsV, ChVectorDynamic<>& statev);
 	double CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, StateVarVector& statev);
     
   private:

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -41,40 +41,32 @@ class ChWoodApi ChWoodMaterialVECT {
     ChWoodMaterialVECT(double rho,  		///< material density
                        double E0,    	///< Mesoscale Young's modulus
                        double alpha,   	///< Mesoscale Poisson like parameter
-                       double sigmat, double sigmas, double nt, double lt, 
-					   double Ed, double sigmac0, double beta, double Hc0,
-					   double Hc1, double kc0, double kc1, double kc2, double kc3,
-					   double mu0, double muinf, double sigmaN0, double kt
-    );
+                       double sigmat, double sigmac, double sigmas,
+                       double nt, double lt, double rs);
     
     ChWoodMaterialVECT();
 
-    /*
-    //copy constructor:
-	ChWoodMaterialVECT(const ChWoodMaterialVECT& my_material);
-	*/
-
-    // Destructor declared:
     ~ChWoodMaterialVECT();
 
     /// Return the material density.
      double Get_density() const { return m_rho; }
-     
      void Set_density(double rho) { m_rho=rho; }
 	
     /// Return the Macroscale Modulus of Elasticity.
     double Get_E0() const { return m_E0; }
-	  
     void Set_E0(double E0) { m_E0=E0; }
     
     /// Return the Macroscale Poisson Ratio.
     double Get_alpha() const { return m_alpha; }
-    
     void Set_alpha(double alpha) { m_alpha=alpha; }
     
     /// Return the tensile strength.
     double Get_sigmat() const { return m_sigmat; }
     void Set_sigmat(double sigmat) { m_sigmat = sigmat; }
+
+    /// Return the compressive yield strength.
+    double Get_sigmac() const { return m_sigmac; }
+    void Set_sigmac(double sigmac) { m_sigmac = sigmac; }
 
     /// Return the shear strength.
     double Get_sigmas() const { return m_sigmas; }
@@ -84,65 +76,13 @@ class ChWoodApi ChWoodMaterialVECT {
     double Get_nt() const { return m_nt; }
     void Set_nt(double nt) { m_nt = nt; }
 
-    /// Return the fracture energy.
-    // double Get_Gt() const { return m_Gt; }
-    // void Set_Gt(double Gt) { m_Gt = Gt; }
-
     /// Return the tensile characteristic length.
     double Get_lt() const { return m_lt; }
     void Set_lt(double lt) { m_lt = lt; }
 
-    /// Return the densified normal modulus.
-    double Get_Ed() const { return m_Ed; }
-    void Set_Ed(double Ed) { m_Ed = Ed; }
-
-    /// Return the compressive yield strength.
-    double Get_sigmac0() const { return m_sigmac0; }
-    void Set_sigmac0(double sigmac0) { m_sigmac0 = sigmac0; }
-
-    /// Return the volunmetric deviatoric coupling.
-    double Get_beta() const { return m_beta; }
-    void Set_beta(double beta) { m_beta = beta; }
-
-    /// Return the initial hardening modulus.
-    double Get_Hc0() const { return m_Hc0; }
-    void Set_Hc0(double Hc0) { m_Hc0 = Hc0; }
-
-    /// Return the final hardening modulus.
-    double Get_Hc1() const { return m_Hc1; }
-    void Set_Hc1(double Hc1) { m_Hc1 = Hc1; }
-
-    /// Return the transitional strain ratio.
-    double Get_kc0() const { return m_kc0; }
-    void Set_kc0(double kc0) { m_kc0 = kc0; }
-
-    /// Return the deviatoric strain threshold ratio.
-    double Get_kc1() const { return m_kc1; }
-    void Set_kc1(double kc1) { m_kc1 = kc1; }
-
-    /// Return the deviatoric damage parameter.
-    double Get_kc2() const { return m_kc2; }
-    void Set_kc2(double kc2) { m_kc2 = kc2; }
-
-    /// Return the material parameter, 0.1.
-    double Get_kc3() const { return m_kc3; }
-    void Set_kc3(double kc3) { m_kc3 = kc3; }
-
-    /// Return the initial friction.
-    double Get_mu0() const { return m_mu0; }
-    void Set_mu0(double mu0) { m_mu0 = mu0; }
-
-    /// Return the asymptotic friction
-    double Get_muinf() const { return m_muinf; }
-    void Set_muinf(double muinf) { m_muinf = muinf; }
-
-    /// Return the transitional stress.
-    double Get_sigmaN0() const { return m_sigmaN0; }
-    void Set_sigmaN0(double sigmaN0) { m_sigmaN0 = sigmaN0; }
-
-    /// Return the tensile unloading.
-    double Get_kt() const { return m_kt; }
-    void Set_kt(double kt) { m_kt = kt; }
+    /// Return the shear softening modulus ratio.
+    double Get_rs() const { return m_rs; }
+    void Set_rs(double rs) { m_rs = rs; }
     
     /// Set and Get RayleighDampingK coefficient.
     double GetRayleighDampingK() const { return RayleighDampingK; }
@@ -174,10 +114,6 @@ class ChWoodApi ChWoodMaterialVECT {
 
     //double CompressBC(ChVectorDynamic<>& mstrain, double& epsV, ChVectorDynamic<>& statev);
 	double CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, StateVarVector& statev);
-
-    std::pair<double, double> ShearBC(ChVector3d& mstrain, StateVarVector& statev);
-	
-	std::vector<double> ShearBC(ChVector3d& mstrain, ChVector3d& curvature, double rN2, StateVarVector& statev);
     
   private:
     
@@ -185,23 +121,11 @@ class ChWoodApi ChWoodMaterialVECT {
     double m_E0;    			///< mesoscale modulus of elasticity
     double m_alpha; 			///< mesoscale Poisson like parameter
     double m_sigmat;            ///< tensile strength
+    double m_sigmac;            ///< compressive yield strength
     double m_sigmas;            ///< shear strength
     double m_nt;                ///< softening exponent
-    //double m_Gt;                ///< fracture energy
     double m_lt;                ///< tensile characteristic length
-    double m_Ed;                ///< densified normal modulus
-    double m_sigmac0;           ///< compressive yield strength
-    double m_beta;              ///< volunmetric deviatoric coupling
-    double m_Hc0;               ///< initial hardening modulus
-    double m_Hc1;               ///< final hardening modulus
-    double m_kc0;               ///< transitional strain ratio
-    double m_kc1;               ///< deviatoric strain threshold ratio
-    double m_kc2;               ///< deviatoric damage parameter
-    double m_kc3;               ///< material parameter, 0.1
-    double m_mu0;               ///< initial friction
-    double m_muinf;             ///< asymptotic friction
-    double m_sigmaN0;           ///< transitional stress.
-    double m_kt;                ///< tensile unloading
+    double m_rs;                ///< shear softening modulus ratio
     double RayleighDampingK=0;
     double RayleighDampingM=0;
     double mcouple_mult=0;

--- a/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
@@ -50,26 +50,17 @@ TEST(CBLConnectorTest, compute_strain){
     my_mesh->SetAutomaticGravity(false);
     sys.Add(my_mesh);
 
-    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(5e-8,
-                                                                0.0, // Zero stiffness to get zero force ?
-                                                                0.2372,
-                                                                30,
-                                                                78.,
-                                                                0.2,
-                                                                5.0,
-                                                                3000,
-                                                                120,
-                                                                0,
-                                                                9900,
-                                                                3000,
-                                                                3,
-                                                                0.5,
-                                                                5,
-                                                                0.1,
-                                                                0.2,
-                                                                0.2,
-                                                                600,
-                                                                1.0); // Not sure what this value of kt should be, not set in Wisdom's demo
+    double rho = 5e-8;
+    double E0 = 0.0; // Zero stiffness to get zero force ?
+    double alpha = 0.2372;
+    double sigmat = 30.0;
+    double sigmac = 120.0;
+    double sigmas = 78.0;
+    double nt = 0.2;
+    double lt = 5.0;
+    double rs = 0.0;
+    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(rho, E0, alpha, sigmat, sigmac, sigmas, nt, lt, rs);
+
     my_mat->SetCoupleMultiplier(1.0);
     my_mat->SetElasticAnalysisFlag(true);
 
@@ -178,35 +169,23 @@ TEST(CBLConnectorTest, elastic_stiffness_matrix){
     my_mesh->SetAutomaticGravity(false);
     sys.Add(my_mesh);
 
+    double rho = 5e-8;
     double E0 = 8000;
     double alpha = 0.2373;
-    double couple_multiplier = 0.761;
-    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(5e-8,
-                                                                E0,
-                                                                alpha,
-                                                                30,
-                                                                78.,
-                                                                0.2,
-                                                                5.0,
-                                                                3000,
-                                                                120,
-                                                                0,
-                                                                9900,
-                                                                3000,
-                                                                3,
-                                                                0.5,
-                                                                5,
-                                                                0.1,
-                                                                0.2,
-                                                                0.2,
-                                                                600,
-                                                                1.0); // Not sure what this value of kt should be, not set in Wisdom's demo
+    double sigmat = 30.0;
+    double sigmac = 120.0;
+    double sigmas = 78.0;
+    double nt = 0.2;
+    double lt = 5.0;
+    double rs = 0.0;
+    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(rho, E0, alpha, sigmat, sigmac, sigmas, nt, lt, rs);
 
     // Small deflection can be used since the void ChElementCBLCON::ComputeStrain function only really performs the
     // computation of the strain according to https://doi.org/10.1016/j.cemconcomp.2011.02.011
     my_mat->SetElasticAnalysisFlag(true);
     ChElementCBLCON::LargeDeflection=false;
     // Bending stiffness computed according to assumptions detailed below
+    double couple_multiplier = 0.761;
     my_mat->SetCoupleMultiplier(couple_multiplier);
     ChElementCBLCON::EnableCoupleForces=true;
 
@@ -319,35 +298,23 @@ TEST(CBLConnectorTest, internal_forces){
     my_mesh->SetAutomaticGravity(false);
     sys.Add(my_mesh);
 
+    double rho = 5e-8;
     double E0 = 8000;
     double alpha = 0.2373;
-    double couple_multiplier = 0.761;
-    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(5e-8,
-                                                                E0,
-                                                                alpha,
-                                                                30,
-                                                                78.,
-                                                                0.2,
-                                                                5.0,
-                                                                3000,
-                                                                120,
-                                                                0,
-                                                                9900,
-                                                                3000,
-                                                                3,
-                                                                0.5,
-                                                                5,
-                                                                0.1,
-                                                                0.2,
-                                                                0.2,
-                                                                600,
-                                                                1.0); // Not sure what this value of kt should be, not set in Wisdom's demo
+    double sigmat = 30.0;
+    double sigmac = 120.0;
+    double sigmas = 78.0;
+    double nt = 0.2;
+    double lt = 5.0;
+    double rs = 0.0;
+    auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>(rho, E0, alpha, sigmat, sigmac, sigmas, nt, lt, rs);
 
     // Small deflection can be used since the void ChElementCBLCON::ComputeStrain function only really performs the
     // computation of the strain according to https://doi.org/10.1016/j.cemconcomp.2011.02.011
     my_mat->SetElasticAnalysisFlag(true);
     ChElementCBLCON::LargeDeflection=false;
     // Bending stiffness computed according to assumptions detailed below
+    double couple_multiplier = 0.761;
     my_mat->SetCoupleMultiplier(couple_multiplier);
     ChElementCBLCON::EnableCoupleForces=true;
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -65,7 +65,6 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double facet_width = 3.165;
     double facet_height = 12.4864;
     double facet_area = facet_height * facet_width;
-    double epsv = 0;
     ChVectorN<double, 18> statev;
     statev.setZero();
     ChVector3d strain(4.186, 1.16, -86.48);
@@ -75,7 +74,7 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     ChVector3d stress;
     ChVector3d couple;
     double random_field = 1.0; // NO RANDOM FIELD
-    my_mat->ComputeStress(strain,curvature, length, epsv, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+    my_mat->ComputeStress(strain,curvature, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
 
 }
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -39,22 +39,11 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double E0 = 8000;
     double alpha = 0.2373;
     double sigmat = 30.0;
+    double sigmac = 120.0;
     double sigmas = 78.0;
     double nt = 0.2;   
     double lt = 5.0;
-    double Ed = 3000.0;
-	double sigmac0 = 120.0;
-	double beta = 0.0;
-    double Hc0 = 9900.0;
-    double Hc1 = 3000.0;
-    double kc0 = 3.0;
-    double kc1 = 0.5;
-    double kc2 = 5.0;
-    double kc3 = 0.1;
-    double mu0 = 0.2;
-    double muinf = 0.2;
-    double sigmaN0 = 600;
-	double kt = 1.0; // Not sure what this value of kt should be, not set in Wisdom's demo
+    double rs = 0.0;
     double couple_multiplier = 0.761;
 
 
@@ -64,20 +53,11 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     my_mat->Set_E0(E0);
     my_mat->Set_alpha(alpha);
     my_mat->Set_sigmat(sigmat);
+    my_mat->Set_sigmac(sigmac);
     my_mat->Set_sigmas(sigmas);
     my_mat->Set_nt(nt);
     my_mat->Set_lt(lt);
-    my_mat->Set_Ed(Ed);
-    my_mat->Set_sigmac0(sigmac0);
-    my_mat->Set_beta(beta);
-    my_mat->Set_Hc0(Hc0);
-    my_mat->Set_Hc1(Hc1);
-    my_mat->Set_kc0(kc0);
-    my_mat->Set_kc1(kc1);
-    my_mat->Set_kc2(kc2);
-    my_mat->Set_kc3(kc3);
-    my_mat->Set_mu0(mu0);
-    my_mat->Set_muinf(muinf);
+    my_mat->Set_rs(rs);
     my_mat->SetCoupleMultiplier(couple_multiplier);
 
     // TODO JBC: test skeleton, not finished, not supposed to work


### PR DESCRIPTION
The code for the constitutive model of CBL connectors has been copied from the code for CSL elements in LDPM.

This PR clean up large parts of the code that were unused or not present in the current formulation present in our Overleaf document. In particular:

1. variable `sigmac0` is renamed `sigmac` and functions `Get_sigmac0()` and `Set_sigmac0()` renamed `Get_sigmac()` and `Set_sigmac()`
2. variable `rs` ("shear softening modulus ratio" in the Overleaf) is introduced.
3. variables `Ed`, `beta`, `Hc0`, `Hc1`, `kc0`, `kc1`, `kc2`, `kc3`, `mu0`, `muinf`, `sigmaN0`, `kt` are deleted
4. functions `shearBC()` are deleted
5. remove volumetric strain argument from input of functions `ComputeStress()`


:warning: These changes modify the order of arguments in the constructors, and the name of the `Set_sigmac0()` function. Therefore, this code is **not backward compatible**.

This PR does not change any existing behavior.