### PR TITLE
Unit test for CBL connector constitutive behavior

### DIFF
--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -411,7 +411,7 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, cyclic_tension) {
     double sigma_t1 = sigmat * std::exp(-Ht * (epsN_path[step1] - sigmat / E0) / sigmat);
     double sigma_t3 = sigmat * std::exp(-Ht * (epsN_path[step3] - sigmat / E0) / sigmat);
     double W_t1 = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps1 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht;
-    double W_t3 = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps3 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigmat * (eps1 - (eps2 + sigma_t1 / E0));
+    double W_t3 = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps3 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigma_t1 * (eps1 - (eps2 + sigma_t1 / E0));
     for (int step : steps) {
         double epsN = epsN_path[step];
         // Normal stress

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -62,21 +62,10 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         E0 = 8000;
         alpha = 0.2373;
         sigmat = 30.0;
+        sigmac = 120.0;
         sigmas = 78.0;
         nt = 0.2;
         lt = 5.0;
-        Ed = 3000.0;
-        sigmac = 120.0;
-        Hc0 = 9900.0;
-        Hc1 = 3000.0;
-        kc0 = 3.0;
-        kc1 = 0.5;
-        kc2 = 5.0;
-        kc3 = 0.1;
-        mu0 = 0.2;
-        muinf = 0.2;
-        sigmaN0 = 600;
-        kt = 1.0; // Not sure what this value of kt should be, not set in Wisdom's demo
         couple_multiplier = 0.761;
         material_is_elastic = false;
         rs = 0.0; // After talk with Wisdom: this is currently assumed to be 0.0
@@ -126,17 +115,7 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         my_mat->Set_sigmas(sigmas);
         my_mat->Set_nt(nt);
         my_mat->Set_lt(lt);
-        my_mat->Set_Ed(Ed);
-        my_mat->Set_sigmac0(sigmac); // After talk with Wisdom, sigmac0 in the code is sigmac in overleaf
-        my_mat->Set_beta(beta);
-        my_mat->Set_Hc0(Hc0);
-        my_mat->Set_Hc1(Hc1);
-        my_mat->Set_kc0(kc0);
-        my_mat->Set_kc1(kc1);
-        my_mat->Set_kc2(kc2);
-        my_mat->Set_kc3(kc3);
-        my_mat->Set_mu0(mu0);
-        my_mat->Set_muinf(muinf);
+        my_mat->Set_sigmac(sigmac);
         my_mat->SetCoupleMultiplier(couple_multiplier);
         my_mat->SetElasticAnalysisFlag(material_is_elastic);
 
@@ -159,7 +138,7 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         for (int t = 1 ; t < nsteps ; t++) {
             ChVector3d strain_increment(epsN_path[t]-epsN_path[t-1], epsM_path[t]-epsM_path[t-1], epsL_path[t]-epsL_path[t-1]);
             ChVector3d curvature_increment(chiN_path[t]-chiN_path[t-1], chiM_path[t]-chiM_path[t-1], chiL_path[t]-chiL_path[t-1]);
-            my_mat->ComputeStress(strain_increment,curvature_increment, length, epsv, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+            my_mat->ComputeStress(strain_increment,curvature_increment, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
 
             if (debug_mode) {
                 res << epsN_path[t]<<", "<<epsM_path[t]<<", "<<epsL_path[t]<<", "<<epsNeqMax_path[t]<<", "<<epsTeqMax_path[t]<<", "<<eps_path[t]<<", "<<chiN_path[t]<<", "<<chiM_path[t]<<", "<<chiL_path[t]<<", ";
@@ -206,28 +185,17 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
     double E0;
     double alpha;
     double sigmat;
+    double sigmac;
     double sigmas;
     double nt;
     double lt;
-    double Ed;
-	double sigmac;
-	double beta;
-    double Hc0;
-    double Hc1;
-    double kc0;
-    double kc1;
-    double kc2;
-    double kc3;
-    double mu0;
-    double muinf;
-    double sigmaN0;
-	double kt; // Not sure what this value of kt should be, not set in Wisdom's demo
     double couple_multiplier;
     double material_is_elastic;
     double rs; // After talk with Wisdom: this is currently assumed to be 0.0
     // Derived parameters
     double Ht;
     double Hs;
+    double beta;
 
     // CBL connector parameters
     double length;

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -233,31 +233,30 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
 
 TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension) {
     // Loading path
-    std::vector<int> t(nsteps);
-    std::iota(t.begin(), t.end(), 0);
-    std::vector<int> tp = {0, nsteps-1};
-    std::vector<double> ep = {0.0, 2 * sigmat / E0};
-    epsN_path = linear_interp(t, tp, ep);
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    std::vector<double> eps_interp = {0.0, 2 * sigmat / E0};
+    epsN_path = linear_interp(steps, steps_interp, eps_interp);
     epsNeqMax_path = epsN_path;
     eps_path = epsN_path;
 
     // Analytical solution
     // w = pi/2 --> sigma0 = sigmat, H0 = Ht
-    for (int step = 0 ; step < nsteps ; step++) {
+    for (int step : steps) {
         double epsN = epsN_path[step];
         // Normal stress
-        if (epsN < sigmat / E0) { // Linear elastic up to epsilon0
+        if (epsN < sigmat / E0) {
             sigN_analytical[step] = E0 * epsN;
             Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
             // No crack
-        } else { // Tensile stress limit beyond epsilon0
+        } else {
             sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
-            crack_analytical[step] = epsN - sigN_analytical[step] / E0;
             Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
+            crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
         }
     }
     sig_analytical = sigN_analytical;
-
 
     LoadingPathTester();
 }

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -475,8 +475,8 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_bending_compression) {
     std::vector<int> steps_interp = {0, nsteps-1};
     double eps_tiny = 1e-16;
     std::vector<double> epsN_interp = {0.0, -eps_tiny}; // Negligle compression to enforce omega --> -pi / 2
-    double rM = facet_width*facet_width / 12;
-    double rL = facet_height*facet_height / 12;
+    double rM = std::sqrt(facet_width*facet_width / 12);
+    double rL = std::sqrt(facet_height*facet_height / 12);
     double chi = (sigmac / E0);
     std::vector<double> chiM_interp = {0.0, chi / rM};
     std::vector<double> chiL_interp = {0.0, -chi / rL};

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -388,6 +388,87 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression_shear) {
     LoadingPathTester();
 }
 
+TEST_F(WoodMaterialVECTTestNoEigenstrain, cyclic_tension) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    int step0 = 0, step1 = int(0.25*nsteps), step2 = int(0.5*nsteps), step3 = int(0.75*nsteps), step4 = nsteps-1;
+    std::vector<int> steps_interp = {step0, step1, step2, step3, step4};
+    double eps0 = 0.0, eps1 = 2 * sigmat / E0, eps2 = sigmat / E0, eps3 = 3 * sigmat / E0, eps4 = 0.0;
+    std::vector<double> eps_interp = {eps0, eps1, eps2, eps3, eps4};
+    epsN_path = linear_interp(steps, steps_interp, eps_interp);
+    eps_path = epsN_path;
+    for (int step : steps) {
+        if (step <= step1)
+            epsNeqMax_path[step] = epsN_path[step];
+        else if (step <= step2)
+            epsNeqMax_path[step] = eps1;
+        else if (step <= step3)
+            epsNeqMax_path[step] = std::max(epsN_path[step], eps1);
+        else
+            epsNeqMax_path[step] = eps3;
+    }
+
+    // Analytical solution
+    // w = pi/2 --> sigma0 = sigmat, H0 = Ht
+    double sigma_t1 = sigmat * std::exp(-Ht * (epsN_path[step1] - sigmat / E0) / sigmat);
+    double sigma_t3 = sigmat * std::exp(-Ht * (epsN_path[step3] - sigmat / E0) / sigmat);
+    double W_t1 = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps1 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
+    double W_t3 = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps3 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigmat * (eps1 - (eps2 + sigma_t1 / E0)));
+    for (int step : steps) {
+        double epsN = epsN_path[step];
+        // Normal stress
+        if (step <= step1) {
+            if (epsN < sigmat / E0) {
+                sigN_analytical[step] = E0 * epsN;
+                Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+                // No crack
+            } else {
+                sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
+                Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
+                crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
+            }
+        } else if (step <= step2) {
+            if (epsN > eps1 - sigma_t1 / E0) {
+                sigN_analytical[step] = sigma_t1 + E0 * (epsN - eps1);
+                Wint_analytical[step] = W_t1 + length * facet_area * (sigma_t1 * (epsN - eps1) + 0.5 * E0 * (epsN - eps1) * (epsN - eps1));
+                crack_analytical[step] = eps1 - sigma_t1 / E0; // Constant crack length during elastic unloading
+            } else {
+                sigN_analytical[step] = 0.0;
+                Wint_analytical[step] = W_t1 - length * facet_area * (0.5 * sigma_t1 * sigma_t1 / E0);
+                crack_analytical[step] = epsN; // Crack closure during unloading at zero stress
+            }
+        } else if (step <= step3) {
+            if (epsN < eps2 + sigma_t1 / E0) {
+                sigN_analytical[step] = E0 * (epsN - eps2);
+                Wint_analytical[step] = W_t1 - length * facet_area * (0.5 * sigma_t1 * sigma_t1 / E0 + 0.5 * E0 * (epsN - eps2) * (epsN - eps2));
+                crack_analytical[step] = eps2; // Constant crack length during elastic reloading
+            } else if (epsN < eps1) {
+                sigN_analytical[step] = sigma_t1;
+                Wint_analytical[step] = W_t1 + length * facet_area * (sigma_t1 * (epsN - (eps2 + sigma_t1 / E0)));
+                crack_analytical[step] = epsN - sigma_t1 / E0; // Crack opening during plastic reloading
+            } else {
+                sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
+                Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigma_t1 * (eps1 - (eps2 + sigma_t1 / E0)));
+                crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
+            }
+        } else {
+            if (epsN > eps3 - sigma_t3 / E0) {
+                sigN_analytical[step] = sigma_t3 + E0 * (epsN - eps3);
+                Wint_analytical[step] = W_t3 + length * facet_area * (sigma_t3 * (epsN - eps3) + 0.5 * E0 * (epsN - eps3) * (epsN - eps3));
+                crack_analytical[step] = eps3 - sigma_t3 / E0; // Constant crack length during elastic unloading
+            } else {
+                sigN_analytical[step] = 0.0;
+                Wint_analytical[step] = W_t3 - length * facet_area * (0.5 * sigma_t3 * sigma_t3 / E0);
+                crack_analytical[step] = epsN; // Crack closure during unloading at zero stress
+            }
+        }
+    }
+    sig_analytical = sigN_analytical;
+
+    LoadingPathTester();
+}
+
 } // namespace
 
 // TODO: EVERYTHING BELOW MUST BE TRANSFERED TO THE FIXTURE, REFACTORED, OR DELETED

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -477,6 +477,55 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, cyclic_tension) {
     LoadingPathTester();
 }
 
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_bending_compression) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    double eps_tiny = 1e-16;
+    std::vector<double> epsN_interp = {0.0, -eps_tiny}; // Negligle compression to enforce omega --> -pi / 2
+    double rM = facet_width*facet_width / 12;
+    double rL = facet_height*facet_height / 12;
+    double chi = (sigmac / E0);
+    std::vector<double> chiM_interp = {0.0, chi / rM};
+    std::vector<double> chiL_interp = {0.0, -chi / rL};
+    epsN_path = linear_interp(steps, steps_interp, epsN_interp);
+    chiM_path = linear_interp(steps, steps_interp, chiM_interp);
+    chiL_path = linear_interp(steps, steps_interp, chiL_interp);
+    for (int step : steps) {
+        epsNeqMax_path[step] = std::sqrt(epsN_path[step] * epsN_path[step] + couple_multiplier * rM * rM * chiM_path[step] * chiM_path[step] + couple_multiplier * rL * rL * chiL_path[step] * chiL_path[step]);
+        eps_path[step] = epsNeqMax_path[step];
+    }
+
+    // Analytical solution
+    //  w = -pi/2 --> sigma0 = sigmac, H0 = 0
+    for (int step : steps) {
+        double eps = eps_path[step];
+        double epsN = epsN_path[step];
+        double chiM = chiM_path[step];
+        double chiL = chiL_path[step];
+        // Normal stress
+        if (eps < sigmac / E0) {
+            sig_analytical[step] = E0 * eps;
+            sigN_analytical[step] = E0 * epsN;
+            muM_analytical[step] = E0 * couple_multiplier * rM * rM * chiM;
+            muL_analytical[step] = E0 * couple_multiplier * rL * rL * chiL;
+            Wint_analytical[step] = 0.5 * E0 * eps * eps;
+            // No crack
+        } else {
+            sig_analytical[step] = sigmac;
+            sigN_analytical[step] = sigmac * epsN / eps; // approx. 0
+            muM_analytical[step] = sigmac * couple_multiplier * rM * rM * chiM / eps; // approx. sigmac * rM / sqrt(2)
+            muL_analytical[step] = sigmac * couple_multiplier * rL * rL * chiL / eps; // approx. -sigmac * rL / sqrt(2)
+            Wint_analytical[step] = 0.5 * sigmac * sigmac / E0 + sigmac * (eps - sigmac / E0);
+            // No crack // TO DISCUSS: I don't think this should be a crack in compression, but the current code does so. Make sure this analytical value is correct
+        }
+        Wint_analytical[step] *= length * facet_area;
+    }
+
+    LoadingPathTester();
+}
+
 } // namespace
 
 // TODO: EVERYTHING BELOW MUST BE TRANSFERED TO THE FIXTURE, REFACTORED, OR DELETED

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -20,14 +20,251 @@
 
 #include "chrono_wood/ChWoodMaterialVECT.h"
 
+#include <numeric>
 #include <vector>
 #include <fstream>
 
 using namespace chrono;
 using namespace wood;
 
-// TODO: Write a Fixture to avoid repeating the code for setting up the test
 
+std::vector<double> linear_interp(std::vector<int> x, std::vector<int> xp, std::vector<double> yp) {
+    // Assumes x and xp increasing
+    // Assumes x[0] = xp[0]
+    // Assumes x[x.size()-1] = xp[xp.size()-1]
+    std::vector<double> y(x.size());
+    for (int i = 0; i < x.size() ; i++) {
+        for (int j = 1 ; j < xp.size() ; j++) { // Inefficient double loop, but this is not performance critical
+            int xp_hi = xp[j];
+            int xi = x[i];
+            if (xi > xp_hi) continue;
+
+            int xp_lo = xp[j-1];
+            double yp_lo = yp[j-1];
+            double yp_hi = yp[j];
+
+            y[i] = yp_lo + (xi - xp_lo) * (yp_hi - yp_lo) / (xp_hi - xp_lo);  // xi should always be in interval [xp_lo ; xp_hi] with our assumptions
+            break;
+        }
+    }
+    return y;
+}
+
+namespace {
+class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
+    protected:
+
+    void SetUp() override {
+        // Default values of material parameters for the test
+        // TODO: select other values if necessary
+        rho = 5e-8;
+        E0 = 8000;
+        alpha = 0.2373;
+        sigmat = 30.0;
+        sigmas = 78.0;
+        nt = 0.2;
+        lt = 5.0;
+        Ed = 3000.0;
+        sigmac = 120.0;
+        beta = 0.0;
+        Hc0 = 9900.0;
+        Hc1 = 3000.0;
+        kc0 = 3.0;
+        kc1 = 0.5;
+        kc2 = 5.0;
+        kc3 = 0.1;
+        mu0 = 0.2;
+        muinf = 0.2;
+        sigmaN0 = 600;
+        kt = 1.0; // Not sure what this value of kt should be, not set in Wisdom's demo
+        couple_multiplier = 0.761;
+        material_is_elastic = false;
+        rs = 0.0; // After talk with Wisdom: this is currently assumed to be 0.0
+
+        // Default CBL connector parameters for the test
+        // TODO: select other values if necessary
+        length = 3.0;
+        facet_width = 3.165;
+        facet_height = 12.4864;
+        epsv = 0; // LEFTOVER FROM LDPM, WILL BE DELETED WITH REBASE
+        random_field = 1.0; // NO RANDOM FIELD
+        facet_area = facet_height * facet_width;
+
+        // Derived parameters: must be manually reset is primary parameters are modified !!!
+        Ht =  2 * E0 / (lt / length - 1.0);
+        Hs =  rs * E0 ;
+
+        // Loading path
+        nsteps = 1000;
+        epsN_path.assign(nsteps, 0.0);
+        epsM_path.assign(nsteps, 0.0);
+        epsL_path.assign(nsteps, 0.0);
+        eps_path.assign(nsteps, 0.0);
+        epsNeqMax_path.assign(nsteps, 0.0);
+        epsTeqMax_path.assign(nsteps, 0.0);
+        chiN_path.assign(nsteps, 0.0);
+        chiM_path.assign(nsteps, 0.0);
+        chiL_path.assign(nsteps, 0.0);
+        sigN_analytical.assign(nsteps, 0.0);
+        sigM_analytical.assign(nsteps, 0.0);
+        sigL_analytical.assign(nsteps, 0.0);
+        sig_analytical.assign(nsteps, 0.0);
+        muN_analytical.assign(nsteps, 0.0);
+        muM_analytical.assign(nsteps, 0.0);
+        muL_analytical.assign(nsteps, 0.0);
+        Wint_analytical.assign(nsteps, 0.0);
+        crack_analytical.assign(nsteps, 0.0);
+    }
+
+    void LoadingPathTester() {
+        auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>();
+        my_mat->Set_density(rho);
+        my_mat->Set_E0(E0);
+        my_mat->Set_alpha(alpha);
+        my_mat->Set_sigmat(sigmat);
+        my_mat->Set_sigmas(sigmas);
+        my_mat->Set_nt(nt);
+        my_mat->Set_lt(lt);
+        my_mat->Set_Ed(Ed);
+        my_mat->Set_sigmac0(sigmac); // After talk with Wisdom, sigmac0 in the code is sigmac in overleaf
+        my_mat->Set_beta(beta);
+        my_mat->Set_Hc0(Hc0);
+        my_mat->Set_Hc1(Hc1);
+        my_mat->Set_kc0(kc0);
+        my_mat->Set_kc1(kc1);
+        my_mat->Set_kc2(kc2);
+        my_mat->Set_kc3(kc3);
+        my_mat->Set_mu0(mu0);
+        my_mat->Set_muinf(muinf);
+        my_mat->SetCoupleMultiplier(couple_multiplier);
+        my_mat->SetElasticAnalysisFlag(material_is_elastic);
+
+        ChVectorN<double, 18> statev;
+        statev.setZero();
+
+        // -------- Test Chrono implementation against analytical -------- //
+        ChVector3d stress(0.0), couple(0.0);
+        for (int t = 1 ; t < nsteps ; t++) {
+            ChVector3d strain_increment(epsN_path[t]-epsN_path[t-1], epsM_path[t]-epsM_path[t-1], epsL_path[t]-epsL_path[t-1]);
+            ChVector3d curvature_increment(chiN_path[t]-chiN_path[t-1], chiM_path[t]-chiM_path[t-1], chiL_path[t]-chiL_path[t-1]);
+            my_mat->ComputeStress(strain_increment,curvature_increment, length, epsv, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+
+            double tol = 1e-6;
+            // The state variables are updatead inside my_mat->ComputeStress()
+            // so they contain the current values.
+            // Maybe we should test for the old values before calling my_mat->ComputeStress() ?
+            ASSERT_NEAR(epsN_path[t], statev(0), tol);
+            ASSERT_NEAR(epsM_path[t], statev(1), tol);
+            ASSERT_NEAR(epsL_path[t], statev(2), tol);
+            ASSERT_NEAR(sigN_analytical[t], statev(3), tol);
+            ASSERT_NEAR(sigM_analytical[t], statev(4), tol);
+            ASSERT_NEAR(sigL_analytical[t], statev(5), tol);
+            ASSERT_NEAR(epsNeqMax_path[t], statev(6), tol);
+            ASSERT_NEAR(epsTeqMax_path[t], statev(7), tol);
+            ASSERT_NEAR(eps_path[t], statev(8), tol);
+            ASSERT_NEAR(sig_analytical[t], statev(9), tol);
+            ASSERT_NEAR(Wint_analytical[t], statev(10), tol);
+            ASSERT_NEAR(crack_analytical[t], statev(11), tol);
+            ASSERT_NEAR(chiN_path[t], statev(12), tol);
+            ASSERT_NEAR(chiM_path[t], statev(13), tol);
+            ASSERT_NEAR(chiL_path[t], statev(14), tol);
+            ASSERT_NEAR(muN_analytical[t], statev(15), tol);
+            ASSERT_NEAR(muM_analytical[t], statev(16), tol);
+            ASSERT_NEAR(muL_analytical[t], statev(17), tol);
+
+            ASSERT_NEAR(sigN_analytical[t], stress[0], tol);
+            ASSERT_NEAR(sigM_analytical[t], stress[1], tol);
+            ASSERT_NEAR(sigL_analytical[t], stress[2], tol);
+            ASSERT_NEAR(muN_analytical[t], couple[0], tol);
+            ASSERT_NEAR(muM_analytical[t], couple[1], tol);
+            ASSERT_NEAR(muL_analytical[t], couple[2], tol);
+        }
+    }
+
+
+    // Material parameters
+    double rho;
+    double E0;
+    double alpha;
+    double sigmat;
+    double sigmas;
+    double nt;
+    double lt;
+    double Ed;
+	double sigmac;
+	double beta;
+    double Hc0;
+    double Hc1;
+    double kc0;
+    double kc1;
+    double kc2;
+    double kc3;
+    double mu0;
+    double muinf;
+    double sigmaN0;
+	double kt; // Not sure what this value of kt should be, not set in Wisdom's demo
+    double couple_multiplier;
+    double material_is_elastic;
+    double rs; // After talk with Wisdom: this is currently assumed to be 0.0
+    // Derived parameters
+    double Ht;
+    double Hs;
+
+    // CBL connector parameters
+    double length;
+    double facet_width;
+    double facet_height;
+    double epsv; // LEFTOVER FROM LDPM, WILL BE DELETED WITH REBASE
+    double random_field;
+    double facet_area;
+
+    // Loading path
+    int nsteps;
+    std::vector<double> epsN_path, epsM_path, epsL_path, eps_path, epsNeqMax_path, epsTeqMax_path; // Strain
+    std::vector<double> chiN_path, chiM_path, chiL_path; // Curvature
+    // Analytical response
+    std::vector<double> sigN_analytical, sigM_analytical, sigL_analytical, sig_analytical;
+    std::vector<double> muN_analytical, muM_analytical, muL_analytical;
+    std::vector<double> Wint_analytical, crack_analytical;
+};
+
+
+
+
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension) {
+    // Loading path
+    std::vector<int> t(nsteps);
+    std::iota(t.begin(), t.end(), 0);
+    std::vector<int> tp = {0, nsteps-1};
+    std::vector<double> ep = {0.0, 2 * sigmat / E0};
+    epsN_path = linear_interp(t, tp, ep);
+    epsNeqMax_path = epsN_path;
+    eps_path = epsN_path;
+
+    // Analytical solution
+    // w = pi/2 --> sigma0 = sigmat, H0 = Ht
+    for (int step = 0 ; step < nsteps ; step++) {
+        double epsN = epsN_path[step];
+        // Normal stress
+        if (epsN < sigmat / E0) { // Linear elastic up to epsilon0
+            sigN_analytical[step] = E0 * epsN;
+            Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+            // No crack
+        } else { // Tensile stress limit beyond epsilon0
+            sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
+            Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / Ht));
+            crack_analytical[step] = epsN - sigN_analytical[step] / E0;
+        }
+    }
+    sig_analytical = sigN_analytical;
+
+
+    LoadingPathTester();
+}
+
+} // namespace
+
+// TODO: EVERYTHING BELOW MUST BE TRANSFERED TO THE FIXTURE, REFACTORED, OR DELETED
 TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     bool debug_mode = true; // true prints results to file. false runs the tests
     std::ofstream res;

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -66,7 +66,6 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         lt = 5.0;
         Ed = 3000.0;
         sigmac = 120.0;
-        beta = 0.0;
         Hc0 = 9900.0;
         Hc1 = 3000.0;
         kc0 = 3.0;
@@ -93,6 +92,7 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         // Derived parameters: must be manually reset is primary parameters are modified !!!
         Ht =  2 * E0 / (lt / length - 1.0);
         Hs =  rs * E0 ;
+        beta = sigmas * sigmas / sigmac * sigmac;
 
         // Loading path
         nsteps = 1000;
@@ -335,6 +335,53 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension_shear) {
             sigL_analytical[step] = alpha * (sig_analytical[step] / eps) * epsL;
             Wint_analytical[step] = length * facet_area * (0.5 * sigma0 * sigma0 / E0 + (1.0 - std::exp(-H0 * (eps - sigma0 / E0) / sigma0)) * sigma0 * sigma0 / H0); // TODO
             crack_analytical[step] = epsN - sigN_analytical[step] / E0; // TO DISCUSS: what should this be theoretically?
+        }
+    }
+
+    LoadingPathTester();
+}
+
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression_shear) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    std::vector<double> epsN_interp = {0.0, -2 * sigmac / E0};
+    std::vector<double> epsM_interp = {0.0, epsN_interp[1] / std::sqrt(2 * alpha)};
+    std::vector<double> epsL_interp = {0.0, -epsN_interp[1] / std::sqrt(2 * alpha)};
+    epsN_path = linear_interp(steps, steps_interp, epsN_interp);
+    epsM_path = linear_interp(steps, steps_interp, epsM_interp);
+    epsL_path = linear_interp(steps, steps_interp, epsL_interp);
+    for (int step : steps) {
+        epsNeqMax_path[step] = -epsN_path[step];
+        epsTeqMax_path[step] = std::sqrt(epsM_path[step] * epsM_path[step] + epsL_path[step] * epsL_path[step]);
+        eps_path[step] = -std::sqrt(2) * epsN_path[step];
+    }
+
+    // Analytical solution
+    // w = pi/4, H_0 = 0
+    double beta = sigmas * sigmas / (sigmac * sigmac);
+    double sigma0 = sigmac * std::sqrt(2*beta / (beta + alpha));
+    for (int step : steps) {
+        double eps = eps_path[step];
+        double epsN = epsN_path[step];
+        double epsM = epsM_path[step];
+        double epsL = epsL_path[step];
+        // Normal stress
+        if (eps < sigma0 / E0) {
+            sig_analytical[step] = E0 * eps;
+            sigN_analytical[step] = E0 * epsN;
+            sigM_analytical[step] = alpha * E0 * epsM;
+            sigL_analytical[step] = alpha * E0 * epsL;
+            Wint_analytical[step] = length * facet_area * (0.5 * E0 * eps * eps);
+            // No crack
+        } else {
+            sig_analytical[step] = sigma0;
+            sigN_analytical[step] = (sigma0 / eps) * epsN;
+            sigM_analytical[step] = alpha * (sigma0 / eps) * epsM;
+            sigL_analytical[step] = alpha * (sigma0 / eps) * epsL;
+            Wint_analytical[step] = length * facet_area * (0.5 * sigma0 * sigma0 / E0 + sigma0 * (eps - sigma0 / E0));
+            // No crack // TO DISCUSS: I don't think this should be a crack in compression, but the current code does so. Make sure this analytical value is correct
         }
     }
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -468,6 +468,56 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, cyclic_tension) {
     LoadingPathTester();
 }
 
+
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_bending_tension) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    double eps_tiny = 1e-16;
+    std::vector<double> epsN_interp = {0.0, eps_tiny}; // Negligle compression to enforce omega --> pi / 2
+    double rM = std::sqrt(facet_width*facet_width / 12);
+    double rL = std::sqrt(facet_height*facet_height / 12);
+    double chi = (sigmac / E0);
+    std::vector<double> chiM_interp = {0.0, chi / rM};
+    std::vector<double> chiL_interp = {0.0, -chi / rL};
+    epsN_path = linear_interp(steps, steps_interp, epsN_interp);
+    chiM_path = linear_interp(steps, steps_interp, chiM_interp);
+    chiL_path = linear_interp(steps, steps_interp, chiL_interp);
+    for (int step : steps) {
+        epsNeqMax_path[step] = std::sqrt(epsN_path[step] * epsN_path[step] + couple_multiplier * rM * rM * chiM_path[step] * chiM_path[step] + couple_multiplier * rL * rL * chiL_path[step] * chiL_path[step]);
+        eps_path[step] = epsNeqMax_path[step];
+    }
+
+    // Analytical solution
+    //  w = pi/2 --> sigma0 = sigmat, H0 = Ht
+    for (int step : steps) {
+        double eps = eps_path[step];
+        double epsN = epsN_path[step];
+        double chiM = chiM_path[step];
+        double chiL = chiL_path[step];
+        // Normal stress
+        if (eps < sigmat / E0) {
+            sig_analytical[step] = E0 * eps;
+            sigN_analytical[step] = E0 * epsN;
+            muM_analytical[step] = E0 * couple_multiplier * rM * rM * chiM;
+            muL_analytical[step] = E0 * couple_multiplier * rL * rL * chiL;
+            Wint_analytical[step] = 0.5 * E0 * eps * eps;
+            // No crack
+        } else {
+            sig_analytical[step] = sigmat * std::exp(-Ht * (eps - sigmat / E0) / sigmat);
+            sigN_analytical[step] = sigmat * std::exp(-Ht * (eps - sigmat / E0) / sigmat) * epsN / eps; // approx. 0
+            muM_analytical[step] = sigmat * std::exp(-Ht * (eps - sigmat / E0) / sigmat) * couple_multiplier * rM * rM * chiM / eps; // approx. (sigmat * std::exp(-Ht * (std::sqrt(2)*couple_multiplier*rM*chiM - sigmat / E0) / sigmat);) * rM / sqrt(2)
+            muL_analytical[step] = sigmat * std::exp(-Ht * (eps - sigmat / E0) / sigmat) * couple_multiplier * rL * rL * chiL / eps; // approx. -(sigmat * std::exp(-Ht * (std::sqrt(2)*couple_multiplier*rL*chiL - sigmat / E0) / sigmat)) * rL / sqrt(2)
+            Wint_analytical[step] = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht;
+            // What is the definition of a crack in bending ?
+        }
+        Wint_analytical[step] *= length * facet_area;
+    }
+
+    LoadingPathTester();
+}
+
 TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_bending_compression) {
     // Loading path
     std::vector<int> steps(nsteps);

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -248,13 +248,15 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension) {
         // Normal stress
         if (epsN < sigmat / E0) {
             sigN_analytical[step] = E0 * epsN;
-            Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+            Wint_analytical[step] = 0.5 * E0 * epsN * epsN;
             // No crack
         } else {
             sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
-            Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
+            Wint_analytical[step] = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht;
             crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
         }
+        Wint_analytical[step] *= length * facet_area;
+        crack_analytical[step] *= length;
     }
     sig_analytical = sigN_analytical;
 
@@ -281,14 +283,15 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression) {
         if (-epsN < sigmac / E0) {
             sigN_analytical[step] = E0 * epsN;
             sig_analytical[step] = -E0 * epsN;
-            Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+            Wint_analytical[step] = 0.5 * E0 * epsN * epsN;
             // No crack
         } else {
             sigN_analytical[step] = -sigmac;
             sig_analytical[step] = sigmac;
-            Wint_analytical[step] = length * facet_area * (0.5 * sigmac * sigmac / E0 - sigmac * (epsN + sigmac / E0));
+            Wint_analytical[step] = 0.5 * sigmac * sigmac / E0 - sigmac * (epsN + sigmac / E0);
             // No crack // TO DISCUSS: I don't think this should be a crack in compression, but the current code does so. Make sure this analytical value is correct
         }
+        Wint_analytical[step] *= length * facet_area;
     }
 
     LoadingPathTester();
@@ -326,16 +329,18 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension_shear) {
             sigN_analytical[step] = E0 * epsN;
             sigM_analytical[step] = alpha * E0 * epsM;
             sigL_analytical[step] = alpha * E0 * epsL;
-            Wint_analytical[step] = length * facet_area * (0.5 * E0 * eps * eps);
+            Wint_analytical[step] = 0.5 * E0 * eps * eps;
             // No crack
         } else {
             sig_analytical[step] = sigma0 * std::exp(-H0 * (eps - sigma0 / E0) / sigma0);
             sigN_analytical[step] = (sig_analytical[step] / eps) * epsN;
             sigM_analytical[step] = alpha * (sig_analytical[step] / eps) * epsM;
             sigL_analytical[step] = alpha * (sig_analytical[step] / eps) * epsL;
-            Wint_analytical[step] = length * facet_area * (0.5 * sigma0 * sigma0 / E0 + (1.0 - std::exp(-H0 * (eps - sigma0 / E0) / sigma0)) * sigma0 * sigma0 / H0); // TODO
+            Wint_analytical[step] = 0.5 * sigma0 * sigma0 / E0 + (1.0 - std::exp(-H0 * (eps - sigma0 / E0) / sigma0)) * sigma0 * sigma0 / H0;
             crack_analytical[step] = epsN - sigN_analytical[step] / E0; // TO DISCUSS: what should this be theoretically?
         }
+        Wint_analytical[step] *= length * facet_area;
+        crack_analytical[step] *= length;
     }
 
     LoadingPathTester();
@@ -373,16 +378,17 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression_shear) {
             sigN_analytical[step] = E0 * epsN;
             sigM_analytical[step] = alpha * E0 * epsM;
             sigL_analytical[step] = alpha * E0 * epsL;
-            Wint_analytical[step] = length * facet_area * (0.5 * E0 * eps * eps);
+            Wint_analytical[step] = 0.5 * E0 * eps * eps;
             // No crack
         } else {
             sig_analytical[step] = sigma0;
             sigN_analytical[step] = (sigma0 / eps) * epsN;
             sigM_analytical[step] = alpha * (sigma0 / eps) * epsM;
             sigL_analytical[step] = alpha * (sigma0 / eps) * epsL;
-            Wint_analytical[step] = length * facet_area * (0.5 * sigma0 * sigma0 / E0 + sigma0 * (eps - sigma0 / E0));
+            Wint_analytical[step] = 0.5 * sigma0 * sigma0 / E0 + sigma0 * (eps - sigma0 / E0);
             // No crack // TO DISCUSS: I don't think this should be a crack in compression, but the current code does so. Make sure this analytical value is correct
         }
+        Wint_analytical[step] *= length * facet_area;
     }
 
     LoadingPathTester();
@@ -413,56 +419,58 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, cyclic_tension) {
     // w = pi/2 --> sigma0 = sigmat, H0 = Ht
     double sigma_t1 = sigmat * std::exp(-Ht * (epsN_path[step1] - sigmat / E0) / sigmat);
     double sigma_t3 = sigmat * std::exp(-Ht * (epsN_path[step3] - sigmat / E0) / sigmat);
-    double W_t1 = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps1 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
-    double W_t3 = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps3 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigmat * (eps1 - (eps2 + sigma_t1 / E0)));
+    double W_t1 = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps1 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht;
+    double W_t3 = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (eps3 - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigmat * (eps1 - (eps2 + sigma_t1 / E0));
     for (int step : steps) {
         double epsN = epsN_path[step];
         // Normal stress
         if (step <= step1) {
             if (epsN < sigmat / E0) {
                 sigN_analytical[step] = E0 * epsN;
-                Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+                Wint_analytical[step] = 0.5 * E0 * epsN * epsN;
                 // No crack
             } else {
                 sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
-                Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
+                Wint_analytical[step] = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht;
                 crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
             }
         } else if (step <= step2) {
             if (epsN > eps1 - sigma_t1 / E0) {
                 sigN_analytical[step] = sigma_t1 + E0 * (epsN - eps1);
-                Wint_analytical[step] = W_t1 + length * facet_area * (sigma_t1 * (epsN - eps1) + 0.5 * E0 * (epsN - eps1) * (epsN - eps1));
+                Wint_analytical[step] = W_t1 + sigma_t1 * (epsN - eps1) + 0.5 * E0 * (epsN - eps1) * (epsN - eps1);
                 crack_analytical[step] = eps1 - sigma_t1 / E0; // Constant crack length during elastic unloading
             } else {
                 sigN_analytical[step] = 0.0;
-                Wint_analytical[step] = W_t1 - length * facet_area * (0.5 * sigma_t1 * sigma_t1 / E0);
+                Wint_analytical[step] = W_t1 - 0.5 * sigma_t1 * sigma_t1 / E0;
                 crack_analytical[step] = epsN; // Crack closure during unloading at zero stress
             }
         } else if (step <= step3) {
             if (epsN < eps2 + sigma_t1 / E0) {
                 sigN_analytical[step] = E0 * (epsN - eps2);
-                Wint_analytical[step] = W_t1 - length * facet_area * (0.5 * sigma_t1 * sigma_t1 / E0 + 0.5 * E0 * (epsN - eps2) * (epsN - eps2));
+                Wint_analytical[step] = W_t1 - 0.5 * sigma_t1 * sigma_t1 / E0 + 0.5 * E0 * (epsN - eps2) * (epsN - eps2);
                 crack_analytical[step] = eps2; // Constant crack length during elastic reloading
             } else if (epsN < eps1) {
                 sigN_analytical[step] = sigma_t1;
-                Wint_analytical[step] = W_t1 + length * facet_area * (sigma_t1 * (epsN - (eps2 + sigma_t1 / E0)));
+                Wint_analytical[step] = W_t1 + sigma_t1 * (epsN - (eps2 + sigma_t1 / E0));
                 crack_analytical[step] = epsN - sigma_t1 / E0; // Crack opening during plastic reloading
             } else {
                 sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
-                Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigma_t1 * (eps1 - (eps2 + sigma_t1 / E0)));
+                Wint_analytical[step] = 0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht + sigma_t1 * (eps1 - (eps2 + sigma_t1 / E0));
                 crack_analytical[step] = epsN - sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / E0;
             }
         } else {
             if (epsN > eps3 - sigma_t3 / E0) {
                 sigN_analytical[step] = sigma_t3 + E0 * (epsN - eps3);
-                Wint_analytical[step] = W_t3 + length * facet_area * (sigma_t3 * (epsN - eps3) + 0.5 * E0 * (epsN - eps3) * (epsN - eps3));
+                Wint_analytical[step] = W_t3 + sigma_t3 * (epsN - eps3) + 0.5 * E0 * (epsN - eps3) * (epsN - eps3);
                 crack_analytical[step] = eps3 - sigma_t3 / E0; // Constant crack length during elastic unloading
             } else {
                 sigN_analytical[step] = 0.0;
-                Wint_analytical[step] = W_t3 - length * facet_area * (0.5 * sigma_t3 * sigma_t3 / E0);
+                Wint_analytical[step] = W_t3 - 0.5 * sigma_t3 * sigma_t3 / E0;
                 crack_analytical[step] = epsN; // Crack closure during unloading at zero stress
             }
         }
+        Wint_analytical[step] *= length * facet_area;
+        crack_analytical[step] *= length;
     }
     sig_analytical = sigN_analytical;
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -145,35 +145,39 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
                 res << sigN_analytical[t]<<", "<<sigM_analytical[t]<<", "<<sigL_analytical[t]<<", "<<sig_analytical[t]<<", "<<muN_analytical[t]<<", "<<muM_analytical[t]<<", "<<muL_analytical[t]<<", "<<Wint_analytical[t]<<", "<<crack_analytical[t]<<", ";
                 res << stress[0]<<", "<<stress[1]<<", "<<stress[2]<<", "<<statev(9)<<", "<<couple[0]<<", "<<couple[1]<<", "<<couple[2]<<", "<<statev(10)<<", "<<statev(11)<<"\n";
             } else {
-                double tol = 1e-6;//std::cout<<t<<", "<<epsN_path[t]<<std::endl;
+                double tol = 1e-10;
+                double tol_sig = 0.5 * (sigmac + sigmat) * tol;
+                double tol_mu = 0.5 * (facet_height + facet_width) * tol_sig;
+                double num_int_factor = 1e4; // Larger tolerance on numerically integrated energy W
+                double tol_W = length * facet_area * 0.25 * (sigmac + sigmat) * (sigmac + sigmat) / E0 * tol * num_int_factor;
                 // The state variables are updatead inside my_mat->ComputeStress()
                 // so they contain the current values.
                 // Maybe we should test for the old values before calling my_mat->ComputeStress() ?
                 ASSERT_NEAR(epsN_path[t], statev(0), tol);
                 ASSERT_NEAR(epsM_path[t], statev(1), tol);
                 ASSERT_NEAR(epsL_path[t], statev(2), tol);
-                ASSERT_NEAR(sigN_analytical[t], statev(3), tol);
-                ASSERT_NEAR(sigM_analytical[t], statev(4), tol);
-                ASSERT_NEAR(sigL_analytical[t], statev(5), tol);
+                ASSERT_NEAR(sigN_analytical[t], statev(3), tol_sig);
+                ASSERT_NEAR(sigM_analytical[t], statev(4), tol_sig);
+                ASSERT_NEAR(sigL_analytical[t], statev(5), tol_sig);
                 ASSERT_NEAR(epsNeqMax_path[t], statev(6), tol);
                 ASSERT_NEAR(epsTeqMax_path[t], statev(7), tol);
                 ASSERT_NEAR(eps_path[t], statev(8), tol);
-                ASSERT_NEAR(sig_analytical[t], statev(9), tol);
-                ASSERT_NEAR(Wint_analytical[t], statev(10), tol);
+                ASSERT_NEAR(sig_analytical[t], statev(9), tol_sig);
+                ASSERT_NEAR(Wint_analytical[t], statev(10), tol_W);
                 ASSERT_NEAR(crack_analytical[t], statev(11), tol);
                 ASSERT_NEAR(chiN_path[t], statev(12), tol);
                 ASSERT_NEAR(chiM_path[t], statev(13), tol);
                 ASSERT_NEAR(chiL_path[t], statev(14), tol);
-                ASSERT_NEAR(muN_analytical[t], statev(15), tol);
-                ASSERT_NEAR(muM_analytical[t], statev(16), tol);
-                ASSERT_NEAR(muL_analytical[t], statev(17), tol);
+                ASSERT_NEAR(muN_analytical[t], statev(15), tol_mu);
+                ASSERT_NEAR(muM_analytical[t], statev(16), tol_mu);
+                ASSERT_NEAR(muL_analytical[t], statev(17), tol_mu);
 
-                ASSERT_NEAR(sigN_analytical[t], stress[0], tol);
-                ASSERT_NEAR(sigM_analytical[t], stress[1], tol);
-                ASSERT_NEAR(sigL_analytical[t], stress[2], tol);
-                ASSERT_NEAR(muN_analytical[t], couple[0], tol);
-                ASSERT_NEAR(muM_analytical[t], couple[1], tol);
-                ASSERT_NEAR(muL_analytical[t], couple[2], tol);
+                ASSERT_NEAR(sigN_analytical[t], stress[0], tol_sig);
+                ASSERT_NEAR(sigM_analytical[t], stress[1], tol_sig);
+                ASSERT_NEAR(sigL_analytical[t], stress[2], tol_sig);
+                ASSERT_NEAR(muN_analytical[t], couple[0], tol_mu);
+                ASSERT_NEAR(muM_analytical[t], couple[1], tol_mu);
+                ASSERT_NEAR(muL_analytical[t], couple[2], tol_mu);
             }
         }
         if (debug_mode) res.close();

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -294,6 +294,53 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression) {
     LoadingPathTester();
 }
 
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension_shear) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    std::vector<double> epsN_interp = {0.0, 2 * sigmat / E0};
+    std::vector<double> epsM_interp = {0.0, epsN_interp[1] / std::sqrt(2 * alpha)};
+    std::vector<double> epsL_interp = {0.0, -epsN_interp[1] / std::sqrt(2 * alpha)};
+    epsN_path = linear_interp(steps, steps_interp, epsN_interp);
+    epsM_path = linear_interp(steps, steps_interp, epsM_interp);
+    epsL_path = linear_interp(steps, steps_interp, epsL_interp);
+    for (int step : steps) {
+        epsNeqMax_path[step] = epsN_path[step];
+        epsTeqMax_path[step] = std::sqrt(epsM_path[step] * epsM_path[step] + epsL_path[step] * epsL_path[step]);
+        eps_path[step] = std::sqrt(2) * epsN_path[step];
+    }
+
+    // Analytical solution
+    // w = pi/4
+    double sigma0 = (2 * sigmat) / (0.5 * std::sqrt(2) + std::sqrt(0.5 + 2*alpha / (sigmas * sigmas / (sigmat * sigmat))));
+    double H0 = Hs / alpha + (Ht - Hs / alpha) / std::pow(2, nt);
+    for (int step : steps) {
+        double eps = eps_path[step];
+        double epsN = epsN_path[step];
+        double epsM = epsM_path[step];
+        double epsL = epsL_path[step];
+        // Normal stress
+        if (eps < sigma0 / E0) {
+            sig_analytical[step] = E0 * eps;
+            sigN_analytical[step] = E0 * epsN;
+            sigM_analytical[step] = alpha * E0 * epsM;
+            sigL_analytical[step] = alpha * E0 * epsL;
+            Wint_analytical[step] = length * facet_area * (0.5 * E0 * eps * eps);
+            // No crack
+        } else {
+            sig_analytical[step] = sigma0 * std::exp(-H0 * (eps - sigma0 / E0) / sigma0);
+            sigN_analytical[step] = (sig_analytical[step] / eps) * epsN;
+            sigM_analytical[step] = alpha * (sig_analytical[step] / eps) * epsM;
+            sigL_analytical[step] = alpha * (sig_analytical[step] / eps) * epsL;
+            Wint_analytical[step] = length * facet_area * (0.5 * sigma0 * sigma0 / E0 + (1.0 - std::exp(-H0 * (eps - sigma0 / E0) / sigma0)) * sigma0 * sigma0 / H0); // TODO
+            crack_analytical[step] = epsN - sigN_analytical[step] / E0; // TO DISCUSS: what should this be theoretically?
+        }
+    }
+
+    LoadingPathTester();
+}
+
 } // namespace
 
 // TODO: EVERYTHING BELOW MUST BE TRANSFERED TO THE FIXTURE, REFACTORED, OR DELETED

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -252,8 +252,8 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension) {
             // No crack
         } else { // Tensile stress limit beyond epsilon0
             sigN_analytical[step] = sigmat * std::exp(-Ht * (epsN - sigmat / E0) / sigmat);
-            Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat) / Ht));
             crack_analytical[step] = epsN - sigN_analytical[step] / E0;
+            Wint_analytical[step] = length * facet_area * (0.5 * sigmat * sigmat / E0 + (1.0 - std::exp(-Ht * (epsN - sigmat / E0) / sigmat)) * sigmat * sigmat / Ht);
         }
     }
     sig_analytical = sigN_analytical;

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -261,6 +261,39 @@ TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_tension) {
     LoadingPathTester();
 }
 
+TEST_F(WoodMaterialVECTTestNoEigenstrain, monotonic_compression) {
+    // Loading path
+    std::vector<int> steps(nsteps);
+    std::iota(steps.begin(), steps.end(), 0);
+    std::vector<int> steps_interp = {0, nsteps-1};
+    std::vector<double> eps_interp = {0.0, -2 * sigmac / E0};
+    epsN_path = linear_interp(steps, steps_interp, eps_interp);
+    for (int step : steps) {
+        epsNeqMax_path[step] = -epsN_path[step];
+        eps_path[step] = -epsN_path[step];
+    }
+
+    // Analytical solution
+    //  w = -pi/2 --> sigma0 = sigmac, H0 = 0
+    for (int step : steps) {
+        double epsN = epsN_path[step];
+        // Normal stress
+        if (-epsN < sigmac / E0) {
+            sigN_analytical[step] = E0 * epsN;
+            sig_analytical[step] = -E0 * epsN;
+            Wint_analytical[step] = length * facet_area * (0.5 * E0 * epsN * epsN);
+            // No crack
+        } else {
+            sigN_analytical[step] = -sigmac;
+            sig_analytical[step] = sigmac;
+            Wint_analytical[step] = length * facet_area * (0.5 * sigmac * sigmac / E0 - sigmac * (epsN + sigmac / E0));
+            // No crack // TO DISCUSS: I don't think this should be a crack in compression, but the current code does so. Make sure this analytical value is correct
+        }
+    }
+
+    LoadingPathTester();
+}
+
 } // namespace
 
 // TODO: EVERYTHING BELOW MUST BE TRANSFERED TO THE FIXTURE, REFACTORED, OR DELETED

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -13,21 +13,15 @@
 // =============================================================================
 
 #include <cmath>
-#include <memory>
-#include "chrono/core/ChMatrix.h"
-#include "chrono/core/ChMatrix33.h"
-#include "chrono/core/ChQuaternion.h"
+
 #include "chrono/core/ChTypes.h"
 #include "chrono/core/ChVector3.h"
-#include "chrono/fea/ChMesh.h"
-#include "chrono/physics/ChSystemSMC.h"
-#include "chrono_wood/ChBeamSectionCBLCON.h"
-#include "chrono_wood/ChBuilderCBLCON.h"
 #include "gtest/gtest.h"
 
 #include "chrono_wood/ChWoodMaterialVECT.h"
 
-#include <chrono>
+#include <vector>
+#include <fstream>
 
 using namespace chrono;
 using namespace wood;
@@ -35,6 +29,10 @@ using namespace wood;
 // TODO: Write a Fixture to avoid repeating the code for setting up the test
 
 TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
+    bool debug_mode = true; // true prints results to file. false runs the tests
+    std::ofstream res;
+    
+    // Material parameters
     double rho = 5e-8;
     double E0 = 8000;
     double alpha = 0.2373;
@@ -45,9 +43,8 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double lt = 5.0;
     double rs = 0.0;
     double couple_multiplier = 0.761;
+    double material_is_elastic = false;
 
-
-    
     auto my_mat = chrono_types::make_shared<ChWoodMaterialVECT>();
     my_mat->Set_density(rho);
     my_mat->Set_E0(E0);
@@ -59,8 +56,9 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     my_mat->Set_lt(lt);
     my_mat->Set_rs(rs);
     my_mat->SetCoupleMultiplier(couple_multiplier);
+    my_mat->SetElasticAnalysisFlag(material_is_elastic);
 
-    // TODO JBC: test skeleton, not finished, not supposed to work
+    // CBL connector parameters
     double length = 3.0;
     double facet_width = 3.165;
     double facet_height = 12.4864;
@@ -76,5 +74,309 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double random_field = 1.0; // NO RANDOM FIELD
     my_mat->ComputeStress(strain,curvature, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
 
+    double hM = 0.5 * facet_height;
+    double hL = 0.5 * facet_width;
+    double rNsq = (hL * hL + hM * hM) / 3.0;
+    double rMsq = (hL * hL) / 3.0;
+    double rLsq = (hM * hM) / 3.0;
+    double betaN(couple_multiplier), betaM(couple_multiplier), betaL(couple_multiplier);
+
+    // Funtions for analytical calculation of the stress in connectors according to
+    // our overleaf project https://www.overleaf.com/project/681aa3904a3faf7f1699077b (replace with Ref once available)
+
+    // Coupling variable
+    auto omega = [alpha](double eN, double eT) {
+        double w;
+        if (eT <= 0.0) { // Effective tangent strain is zero
+            if (eN > 0.0)      w = 0.5 * M_PI;
+            else if (eN < 0.0) w = - 0.5 * M_PI;
+            else               w = 0.0; // TO DISCUSS: not sure the value for this 0/0 undefined case matters
+        }
+        else                   w = std::atan(eN / (eT * std::sqrt(alpha)));
+        return w;
+    };
+
+    // Strength decay function
+    auto epsilon_1 = [](double e, double emax, double w) {
+        double e1 = e;
+        if (w > 0.0) e1 = emax;
+        return e1;
+    };
+
+    // Elastic stress limit
+    auto sigma_0 = [sigmas, sigmat, sigmac, alpha](double w) {
+        double s0;
+        double rst = sigmas / sigmat;
+        double beta = (sigmas * sigmas) / (sigmac * sigmac);
+        if (w > 0.0) {
+            // The standard equation: s0 = sigmat * (-std::sin(w) + std::sqrt(std::sin(w)*std::sin(w) +
+            //                                       4 * a * std::cos(w)*std::cos(w) / (rst * rst)) ) /
+            //                                      (2 * a * std::cos(w)*std::cos(w) / (rst * rst) );
+            // is indeterminate for w -> pi/2 so we rationalize the expression
+            // by multiplying both the numerator and denominator by the numerator's conjugate
+            s0 = sigmat * 2 / (std::sin(w) + std::sqrt(std::sin(w)*std::sin(w) + 4 * alpha * std::cos(w)*std::cos(w) / (rst * rst)) );
+        }
+        else         s0 = sigmac / std::sqrt(std::sin(w)*std::sin(w) + alpha * std::cos(w)*std::cos(w) / beta);
+        return s0;
+    };
+
+    // Softening modulus
+    // TODO: what is rs ?!?! Not given i the CBL code right now. Is it the same as rst ?
+    auto H_0 = [E0, alpha, nt, lt, rs](double w, double l) {
+        double h0 = 0.0;
+        if (w > 0.0) {
+            double Ht =  2 * E0 / (lt / l - 1.0);
+            double Hs =  rs * E0 ;
+            h0 = Hs / alpha + (Ht - Hs / alpha) * std::pow(2*w / M_PI, nt);
+        }
+        return h0;
+    };
+
+    // Limiting stress
+    auto sigma_bs = [&omega, &epsilon_1, &sigma_0, &H_0, E0](double w, double e, double emax, double l) {
+        double sig0 = sigma_0(w);
+        double H0 = H_0(w, l);
+        double eps1 = epsilon_1(e, emax, w);
+        double eps0 = sig0 / E0;
+        return sig0 * std::exp(-H0 * std::max(emax - eps0, 0.0) / sig0);
+    };
+
+
+    // --------- Loading paths --------- //
+    int npaths = 10;
+    int nsteps = 1000;
+    // Strain
+    std::vector<std::vector<double>> epsN_paths(npaths, std::vector<double>(nsteps));
+    std::vector<std::vector<double>> epsM_paths(npaths, std::vector<double>(nsteps));
+    std::vector<std::vector<double>> epsL_paths(npaths, std::vector<double>(nsteps));
+    // Curvature
+    std::vector<std::vector<double>> chiN_paths(npaths, std::vector<double>(nsteps));
+    std::vector<std::vector<double>> chiM_paths(npaths, std::vector<double>(nsteps));
+    std::vector<std::vector<double>> chiL_paths(npaths, std::vector<double>(nsteps));
+
+    double eps_tension(2 * sigmat / E0);
+    double eps_compression(-2 * sigmac / E0);
+    double eps_shearM(0.1 * (eps_tension - eps_compression));
+    double eps_shearL(-0.2 * (eps_tension - eps_compression));
+
+    double chi_torsion(2 * sigmas / (alpha * E0) / std::sqrt(rNsq));
+    double chi_bendingM(2 * sigmat / E0 / hL);
+    double chi_bendingL(-2 * sigmat / E0 / hM);
+
+    for (int t = 0 ; t < nsteps ; t++) { // TODO: it is a bit clunky to add new cases by manually giving the index. Just use push_back()
+        double ramp = double(t)/(nsteps - 1);
+        // Path 0 : pure monotonic tension
+        epsN_paths[0][t] = eps_tension * ramp;
+        epsM_paths[0][t] = 0.0;
+        epsL_paths[0][t] = 0.0;
+        chiN_paths[0][t] = 0.0;
+        chiM_paths[0][t] = 0.0;
+        chiL_paths[0][t] = 0.0;
+
+        // Path 1 : pure monotonic compression
+        epsN_paths[1][t] = eps_compression * ramp;
+        epsM_paths[1][t] = 0.0;
+        epsL_paths[1][t] = 0.0;
+        chiN_paths[1][t] = 0.0;
+        chiM_paths[1][t] = 0.0;
+        chiL_paths[1][t] = 0.0;
+
+        // Path 2 : monotonic compression + shear
+        epsN_paths[2][t] = eps_compression * ramp;
+        epsM_paths[2][t] = eps_shearM * ramp;
+        epsL_paths[2][t] = eps_shearL * ramp;
+        chiN_paths[2][t] = 0.0;
+        chiM_paths[2][t] = 0.0;
+        chiL_paths[2][t] = 0.0;
+
+        // Path 3 : monotonic tension + shear
+        epsN_paths[3][t] = eps_tension * ramp;
+        epsM_paths[3][t] = eps_shearM * ramp;
+        epsL_paths[3][t] = eps_shearL * ramp;
+        chiN_paths[3][t] = 0.0;
+        chiM_paths[3][t] = 0.0;
+        chiL_paths[3][t] = 0.0;
+
+        // Path 4: monotonic compression + bending
+        epsN_paths[4][t] = eps_compression * ramp;
+        epsM_paths[4][t] = 0.0;
+        epsL_paths[4][t] = 0.0;
+        chiN_paths[4][t] = 0.0;
+        chiM_paths[4][t] = chi_bendingM * ramp;
+        chiL_paths[4][t] = chi_bendingL * ramp;
+
+        // Path 5: monotonic tension + bending
+        epsN_paths[5][t] = eps_tension * ramp;
+        epsM_paths[5][t] = 0.0;
+        epsL_paths[5][t] = 0.0;
+        chiN_paths[5][t] = 0.0;
+        chiM_paths[5][t] = chi_bendingM * ramp;
+        chiL_paths[5][t] = chi_bendingL * ramp;
+
+        // Path 6: monotonic tension + torsion
+        epsN_paths[6][t] = eps_tension * ramp;
+        epsM_paths[6][t] = 0.0;
+        epsL_paths[6][t] = 0.0;
+        chiN_paths[6][t] = chi_torsion * ramp;
+        chiM_paths[6][t] = 0.0;
+        chiL_paths[6][t] = 0.0;
+
+        // Path 7: monotonic tension + torsion + bending
+        epsN_paths[7][t] = eps_tension * ramp;
+        epsM_paths[7][t] = 0.0;
+        epsL_paths[7][t] = 0.0;
+        chiN_paths[7][t] = chi_torsion * ramp;
+        chiM_paths[7][t] = chi_bendingM * ramp;
+        chiL_paths[7][t] = chi_bendingL * ramp;
+
+        // Path 8: monotonic tension + shear + torsion + bending
+        epsN_paths[8][t] = eps_tension * ramp;
+        epsM_paths[8][t] = eps_shearM * ramp;
+        epsL_paths[8][t] = eps_shearL * ramp;
+        chiN_paths[8][t] = chi_torsion * ramp;
+        chiM_paths[8][t] = chi_bendingM * ramp;
+        chiL_paths[8][t] = chi_bendingL * ramp;
+    }
+
+    // Comparison of analytical calculations and Chrono implementation for all loading paths
+    for (int path = 0 ; path < npaths ; path++) {
+        // Initialize history and incremental variables
+        double sig = 0.0;
+        double epsNeqMax = 0.0;
+        double epsTeqMax = 0.0;
+        double epsold = 0.0;
+        double sigNold = 0.0;
+        double sigMold = 0.0;
+        double sigLold = 0.0;
+        double muNold = 0.0;
+        double muMold = 0.0;
+        double muLold = 0.0;
+        double Wint = 0.0;
+
+        ChVectorN<double, 18> statev;
+        statev.setZero();
+
+        if (debug_mode) { // Output to file to plot
+            res.open ("results_path"+std::to_string(path)+".csv");
+            res << "# Analytical solution from unit test WOOD_MaterialVECTTest - stress_no_eigenstrain.\n";
+            res << "# E0="<<E0<<", alpha="<<alpha<<", sigmat="<<sigmat<<", sigmac="<<sigmac<<", sigmas="<<sigmas<<", nt="<<nt<<", lt="<<lt<<", couple_mult="<<couple_multiplier<<"\n";
+            res << "epsN, epsM, epsL, epsNeqMax, epsTeqMax, epsmax, sigN, sigM, sigL, sig, muN, muM, muL, Wint, crack\n";
+            res << "0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0\n";
+        }
+        for (int t = 1 ; t < nsteps ; t++) {
+            double epsN = epsN_paths[path][t];
+            double epsM = epsM_paths[path][t];
+            double epsL = epsL_paths[path][t];
+            double epsNincr = epsN - epsN_paths[path][t-1];
+            double epsMincr = epsM - epsM_paths[path][t-1];
+            double epsLincr = epsL - epsL_paths[path][t-1];
+            double chiN = chiN_paths[path][t];
+            double chiM = chiM_paths[path][t];
+            double chiL = chiL_paths[path][t];
+            double chiNincr = chiN - chiN_paths[path][t-1];
+            double chiMincr = chiM - chiM_paths[path][t-1];
+            double chiLincr = chiL - chiL_paths[path][t-1];
+
+            // -------- Analytical calculation -------- //
+
+            double epsT = std::sqrt(epsM * epsM + epsL * epsL);
+            double epsNeq = std::sqrt(epsN * epsN +  betaM * rMsq * chiM * chiM + betaL * rLsq * chiL * chiL);
+            double epsTeq = std::sqrt(epsM * epsM + epsL * epsL + betaN * rNsq * chiN * chiN);
+            double eps = std::sqrt(epsNeq * epsNeq + alpha * epsTeq * epsTeq);            
+            epsNeqMax = std::max(epsNeqMax, epsNeq);
+            epsTeqMax = std::max(epsTeqMax, epsTeq);
+            double epsmax = std::sqrt(epsNeqMax * epsNeqMax + alpha * epsTeqMax * epsTeqMax);
+            double w = omega(epsN, epsT);
+
+            // Elastic prediction
+            sig += E0 * (eps - epsold);
+
+            // Correction (return)
+            double sigbs = sigma_bs(w, eps, epsmax, length);
+            if (sig < 0.0) sig = 0.0;
+            if (sig > sigbs) sig = sigbs;
+
+            // Stress and torque components
+            double sigN(0.0), sigM(0.0), sigL(0.0);
+            double muN(0.0), muM(0.0), muL(0.0);
+            if (eps > 0.0) { // TODO: is there anything safer ? MIN_DBL ?
+                sigN = sig * epsN / eps;
+                sigM = sig * alpha * epsM / eps;
+                sigL = sig * alpha * epsL / eps;
+                muN = sig * betaN * rNsq * alpha * chiN / eps;
+                muM = sig * betaM * rMsq * chiM / eps;
+                muL = sig * betaL * rLsq * chiL / eps;
+            }
+
+            // Total Energy of mechanical deformation (trapezoidal integration)
+            Wint += length * facet_area * (epsNincr * 0.5 * (sigNold + sigN) + epsMincr * 0.5 * (sigMold + sigM) + epsLincr * 0.5 * (sigLold + sigL) +
+                                           chiNincr * 0.5 * (muNold + muN)  + chiMincr * 0.5 * (muMold + muM) + chiLincr * 0.5 * (muLold + muL));
+
+            // Crack Opening
+            double crackN = length * std::max(epsN - sigN / E0, 0.0); // Normal Crack if positive
+            double crackM = length * (epsM - sigM / (alpha * E0)); // Is this tangential sliding really a "crack" ?
+            double crackL = length * (epsL - sigL / (alpha * E0)); // Is this tangential sliding really a "crack" ?
+            double crack = std::sqrt(crackN * crackN + crackM * crackM + crackL * crackL);
+
+            // Update for next increment
+            epsold = eps;
+            sigNold = sigN;
+            sigMold = sigM;
+            sigLold = sigL;
+            muNold = muN;
+            muMold = muM;
+            muLold = muL;
+
+            // -------- Chrono implementation -------- //
+
+            ChVector3d strain_increment(epsNincr, epsMincr, epsMincr);
+            ChVector3d curvature_increment(chiNincr, chiMincr, chiLincr);
+            ChVector3d stress, couple;
+            my_mat->ComputeStress(strain_increment,curvature_increment, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+
+            // ---------------------------------------- //
+            // -------- Comparison and Testing -------- //
+            // ---------------------------------------- //
+
+            if (!debug_mode) {
+                double tol = 1e-10;
+
+                // The state variables are updatead inside my_mat->ComputeStress()
+                // so they contain the current values.
+                // Maybe we should test for the old values before calling my_mat->ComputeStress() ?
+                ASSERT_NEAR(epsN, statev(0), tol);
+                ASSERT_NEAR(epsM, statev(1), tol);
+                ASSERT_NEAR(epsL, statev(2), tol);
+                ASSERT_NEAR(sigN, statev(3), tol);
+                ASSERT_NEAR(sigM, statev(4), tol);
+                ASSERT_NEAR(sigL, statev(5), tol);
+                ASSERT_NEAR(epsNeqMax, statev(6), tol);
+                ASSERT_NEAR(epsTeqMax, statev(7), tol);
+                ASSERT_NEAR(eps, statev(8), tol);
+                ASSERT_NEAR(sig, statev(9), tol);
+                ASSERT_NEAR(Wint, statev(10), tol);
+                ASSERT_NEAR(crack, statev(11), tol);
+                ASSERT_NEAR(chiN, statev(12), tol);
+                ASSERT_NEAR(chiM, statev(13), tol);
+                ASSERT_NEAR(chiL, statev(14), tol);
+                ASSERT_NEAR(muN, statev(15), tol);
+                ASSERT_NEAR(muM, statev(16), tol);
+                ASSERT_NEAR(muL, statev(17), tol);
+
+                ASSERT_NEAR(sigN, stress[0], tol);
+                ASSERT_NEAR(sigM, stress[1], tol);
+                ASSERT_NEAR(sigL, stress[2], tol);
+                ASSERT_NEAR(muN, couple[0], tol);
+                ASSERT_NEAR(muM, couple[1], tol);
+                ASSERT_NEAR(muL, couple[2], tol);
+            }
+
+            if (debug_mode) {// Output
+                res<<epsN<<", "<<epsM<<", "<<epsL<<", "<<epsNeqMax<<", "<<epsTeqMax<<", "<<epsmax<<", "<<sigN<<", "<<sigM<<", "<<sigL<<", "<<sig<<", "<<muN<<", "<<muM<<", "<<muL<<", "<<Wint<<", "<<crack<<std::endl;
+            }
+        }
+
+        res.close();
+    }
 }
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -55,6 +55,7 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
     protected:
 
     void SetUp() override {
+        debug_mode = false;
         // Default values of material parameters for the test
         // TODO: select other values if necessary
         rho = 5e-8;
@@ -143,42 +144,60 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
         statev.setZero();
 
         // -------- Test Chrono implementation against analytical -------- //
+        if (debug_mode) {
+            std::string testname = ::testing::UnitTest::GetInstance()->current_test_info()->name();
+            res.open ("results_WOODMaterialVECTTestNoEigenstrain."+testname+".csv");
+            res << "# Analytical and Chrono solutions for unit test WOODMaterialVECTTestNoEigenstrain."+testname+"\n";
+            res << "epsN, epsM, epsL, epsNeqMax, epsTeqMax, eps, chiN, chiM, chiL, "; // inputs
+            res << "sigN_analytical, sigM_analytical, sigL_analytical, sig_analytical, muN_analytical, muM_analytical, muL_analytical, Wint_analytical, crack_analytical, ";
+            res << "sigN_chrono, sigM_chrono, sigL_chrono, sig_chrono, muN_chrono, muM_chrono, muL_chrono, Wint_chrono, crack_chrono\n";
+            res << "0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ";
+            res << "0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, ";
+            res << "0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0\n";
+        }
         ChVector3d stress(0.0), couple(0.0);
         for (int t = 1 ; t < nsteps ; t++) {
             ChVector3d strain_increment(epsN_path[t]-epsN_path[t-1], epsM_path[t]-epsM_path[t-1], epsL_path[t]-epsL_path[t-1]);
             ChVector3d curvature_increment(chiN_path[t]-chiN_path[t-1], chiM_path[t]-chiM_path[t-1], chiL_path[t]-chiL_path[t-1]);
             my_mat->ComputeStress(strain_increment,curvature_increment, length, epsv, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
 
-            double tol = 1e-6;
-            // The state variables are updatead inside my_mat->ComputeStress()
-            // so they contain the current values.
-            // Maybe we should test for the old values before calling my_mat->ComputeStress() ?
-            ASSERT_NEAR(epsN_path[t], statev(0), tol);
-            ASSERT_NEAR(epsM_path[t], statev(1), tol);
-            ASSERT_NEAR(epsL_path[t], statev(2), tol);
-            ASSERT_NEAR(sigN_analytical[t], statev(3), tol);
-            ASSERT_NEAR(sigM_analytical[t], statev(4), tol);
-            ASSERT_NEAR(sigL_analytical[t], statev(5), tol);
-            ASSERT_NEAR(epsNeqMax_path[t], statev(6), tol);
-            ASSERT_NEAR(epsTeqMax_path[t], statev(7), tol);
-            ASSERT_NEAR(eps_path[t], statev(8), tol);
-            ASSERT_NEAR(sig_analytical[t], statev(9), tol);
-            ASSERT_NEAR(Wint_analytical[t], statev(10), tol);
-            ASSERT_NEAR(crack_analytical[t], statev(11), tol);
-            ASSERT_NEAR(chiN_path[t], statev(12), tol);
-            ASSERT_NEAR(chiM_path[t], statev(13), tol);
-            ASSERT_NEAR(chiL_path[t], statev(14), tol);
-            ASSERT_NEAR(muN_analytical[t], statev(15), tol);
-            ASSERT_NEAR(muM_analytical[t], statev(16), tol);
-            ASSERT_NEAR(muL_analytical[t], statev(17), tol);
+            if (debug_mode) {
+                res << epsN_path[t]<<", "<<epsM_path[t]<<", "<<epsL_path[t]<<", "<<epsNeqMax_path[t]<<", "<<epsTeqMax_path[t]<<", "<<eps_path[t]<<", "<<chiN_path[t]<<", "<<chiM_path[t]<<", "<<chiL_path[t]<<", ";
+                res << sigN_analytical[t]<<", "<<sigM_analytical[t]<<", "<<sigL_analytical[t]<<", "<<sig_analytical[t]<<", "<<muN_analytical[t]<<", "<<muM_analytical[t]<<", "<<muL_analytical[t]<<", "<<Wint_analytical[t]<<", "<<crack_analytical[t]<<", ";
+                res << stress[0]<<", "<<stress[1]<<", "<<stress[2]<<", "<<statev(9)<<", "<<couple[0]<<", "<<couple[1]<<", "<<couple[2]<<", "<<statev(10)<<", "<<statev(11)<<"\n";
+            } else {
+                double tol = 1e-6;//std::cout<<t<<", "<<epsN_path[t]<<std::endl;
+                // The state variables are updatead inside my_mat->ComputeStress()
+                // so they contain the current values.
+                // Maybe we should test for the old values before calling my_mat->ComputeStress() ?
+                ASSERT_NEAR(epsN_path[t], statev(0), tol);
+                ASSERT_NEAR(epsM_path[t], statev(1), tol);
+                ASSERT_NEAR(epsL_path[t], statev(2), tol);
+                ASSERT_NEAR(sigN_analytical[t], statev(3), tol);
+                ASSERT_NEAR(sigM_analytical[t], statev(4), tol);
+                ASSERT_NEAR(sigL_analytical[t], statev(5), tol);
+                ASSERT_NEAR(epsNeqMax_path[t], statev(6), tol);
+                ASSERT_NEAR(epsTeqMax_path[t], statev(7), tol);
+                ASSERT_NEAR(eps_path[t], statev(8), tol);
+                ASSERT_NEAR(sig_analytical[t], statev(9), tol);
+                ASSERT_NEAR(Wint_analytical[t], statev(10), tol);
+                ASSERT_NEAR(crack_analytical[t], statev(11), tol);
+                ASSERT_NEAR(chiN_path[t], statev(12), tol);
+                ASSERT_NEAR(chiM_path[t], statev(13), tol);
+                ASSERT_NEAR(chiL_path[t], statev(14), tol);
+                ASSERT_NEAR(muN_analytical[t], statev(15), tol);
+                ASSERT_NEAR(muM_analytical[t], statev(16), tol);
+                ASSERT_NEAR(muL_analytical[t], statev(17), tol);
 
-            ASSERT_NEAR(sigN_analytical[t], stress[0], tol);
-            ASSERT_NEAR(sigM_analytical[t], stress[1], tol);
-            ASSERT_NEAR(sigL_analytical[t], stress[2], tol);
-            ASSERT_NEAR(muN_analytical[t], couple[0], tol);
-            ASSERT_NEAR(muM_analytical[t], couple[1], tol);
-            ASSERT_NEAR(muL_analytical[t], couple[2], tol);
+                ASSERT_NEAR(sigN_analytical[t], stress[0], tol);
+                ASSERT_NEAR(sigM_analytical[t], stress[1], tol);
+                ASSERT_NEAR(sigL_analytical[t], stress[2], tol);
+                ASSERT_NEAR(muN_analytical[t], couple[0], tol);
+                ASSERT_NEAR(muM_analytical[t], couple[1], tol);
+                ASSERT_NEAR(muL_analytical[t], couple[2], tol);
+            }
         }
+        if (debug_mode) res.close();
     }
 
 
@@ -226,6 +245,10 @@ class WoodMaterialVECTTestNoEigenstrain : public testing::Test {
     std::vector<double> sigN_analytical, sigM_analytical, sigL_analytical, sig_analytical;
     std::vector<double> muN_analytical, muM_analytical, muL_analytical;
     std::vector<double> Wint_analytical, crack_analytical;
+
+    // DEBUG
+    bool debug_mode;
+    std::ofstream res;
 };
 
 


### PR DESCRIPTION
This PR implements a unit test for the CBL connector constitutive model calculated by `ChWoodMaterialVECT::ComputeStress()`.

The test replicates the analytical formulation [in our Overleaf](https://www.overleaf.com/project/681aa3904a3faf7f1699077b).

The test function currently has 2 modes accessible by toggling the `debug_mode` flag at the beginning of the `TEST` function:
- `debug_mode = true` prints the analytical results to file and was used during development to make sure the test correctly implements the analytical formulation.
  - I plotted the output to make sure the results **look** correct.
  - Reviewer are now responsible to double check that the formulation in the test **is** correct.
- `debug_mode = false` runs the actual test using gtest utilies, it does not print anything to file.
  - Note that *the current implementation does not pass the test!*, which means that the implementation of the function `ChWoodMaterialVECT::ComputeStress()` is likely incorrect
  - a subsequent PR will fix and refactor the function `ChWoodMaterialVECT::ComputeStress()` so that it passes the test. This PR only focuses on implementing the test. **Please review thetest only, do no attempt to fix the function until we have a functional test to test against**, thank you