### PR TITLE
Combine CBL connectors ComputeStress() functions into one to avoid code duplication and fix bugs

### DIFF
--- a/src/chrono_wood/ChBeamSectionCBLCON.cpp
+++ b/src/chrono_wood/ChBeamSectionCBLCON.cpp
@@ -70,7 +70,7 @@ void ChBeamSectionCBLCON::ComputeProjectionMatrix() {
 };
 
 void ChBeamSectionCBLCON::ComputeEigenStrain(std::shared_ptr<ChMatrixNM<double,1,9>> macro_strain){
-	ChVectorDynamic<> eigen_strain;					
+	ChVector3d eigen_strain;
 	auto pp=this->GetProjectionMatrix();
 	eigen_strain = -pp * macro_strain->transpose();	
 	this->Set_nonMechanicStrain(eigen_strain);				

--- a/src/chrono_wood/ChBeamSectionCBLCON.h
+++ b/src/chrono_wood/ChBeamSectionCBLCON.h
@@ -114,8 +114,8 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
 	
 	void ComputeEigenStrain(std::shared_ptr<ChMatrixNM<double,1,9>> macro_strain);
 	
-	ChVectorDynamic<>  Get_nonMechanicStrain() const { return m_nonMechanicStrain; };
-    void Set_nonMechanicStrain(ChVectorDynamic<>  nonMechanicStrain) { m_nonMechanicStrain=nonMechanicStrain; } 
+	ChVector3d Get_nonMechanicStrain() const { return m_nonMechanicStrain; };
+    void Set_nonMechanicStrain(ChVector3d nonMechanicStrain) { m_nonMechanicStrain=nonMechanicStrain; }
     
     
   protected:
@@ -123,7 +123,7 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
     ChVector3d m_center;
     ChMatrix33<double> m_facetFrame;
     StateVarVector m_state;
-	ChVectorDynamic<>  m_nonMechanicStrain;
+	ChVector3d  m_nonMechanicStrain;
     //std::shared_ptr<ChInternalDataCSL> m_state;  
     double mcon_width=1.0;  
     double mcon_height=1.0; 

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -119,7 +119,10 @@ void ChElementCBLCON::Update() {
     }
     //
     if(this->macro_strain){
+        // TODO JBC: I think this should also update the projection matrix for eigenstrains. TBD when large deflection is actually implemented
         this->section->ComputeEigenStrain(this->macro_strain);
+    } else { // JBC: This might not be necessary since the value of 0.0 in SetupInitial() should remain if macro_strain is nullptr
+        this->section->Set_nonMechanicStrain(ChVector3d(0.0, 0.0, 0.0));
     }
     // get displacement increment between current step and previous step
     // update total displacement increment
@@ -518,6 +521,8 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
     if(this->macro_strain){
             this->section->ComputeProjectionMatrix();
             this->section->ComputeEigenStrain(this->macro_strain);
+    } else {
+        this->section->Set_nonMechanicStrain(ChVector3d(0.0, 0.0, 0.0));
     }
 
     //
@@ -758,11 +763,8 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     double random_field =mysection->GetRandomField();
 
     auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
-    if (nonMechanicalStrain.size()){
-        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
-    }else{
-        mysection->Get_material()->ComputeStress( dmstrain, dcurvature, length, statev, area, width, height, random_field, mstress, mcouple);
-    }
+    mysection->Get_material()->ComputeStress( dmstrain, dcurvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
+
 
     mysection->Set_StateVar(statev);
 

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -74,7 +74,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]);
 		epsQN = mstrain[0];
 	}else{	
-		double multiplier=this->GetCoupleMultiplier()/3.;					
+		double multiplier=this->GetCoupleMultiplier()/3.;
 		mcurvature=statev.segment(12,3)+dmcurvature.eigen();
 		//std::cout<<"mstrain: "<<mstrain<<" mcurvature: "<<mcurvature<<std::endl;
 		//std::cout<<"curvature: "<<mcurvature<<std::endl;		
@@ -142,19 +142,27 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		statev(3) = mstress[0];                  //           while a loading step did happen!
 		statev(4) = mstress[1];                  //           I am leaving this as is for now because we will refactor this in depth soon!
 		statev(5) = mstress[2];                  //           The current fix aims to retrieve the "old" behavior
-		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account? This differs from the Overleaf formulation!
-		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account? This differs from the Overleaf formulation!
-		statev(10) = Wint + statev(10);
+        statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2)));
+        statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha);
+        statev(10) = Wint + statev(10);
 		statev(11) = w;
 		//
-		if(this->GetCoupleMultiplier()){				
-				statev(12) = mcurvature[0];
-				statev(13) = mcurvature[1];
-				statev(14) = mcurvature[2];	
-				//
-				statev(15) = mcouple[0];
-				statev(16) = mcouple[1];
-				statev(17) = mcouple[2];
+		if(this->GetCoupleMultiplier()){
+            statev(12) = mcurvature[0];
+            statev(13) = mcurvature[1];
+            statev(14) = mcurvature[2];
+            //
+            statev(15) = mcouple[0];
+            statev(16) = mcouple[1];
+            statev(17) = mcouple[2];
+            // TODO: below is temporary just to fix the bugs from improperly defined effective strain / stress. Will refactor later
+            double multiplier=this->GetCoupleMultiplier()/3.;
+            statev(8) = std::sqrt(statev(8) * statev(8) +
+                                  multiplier * (statev(13) * statev(13) * w2 + statev(14) * statev(14) * h2 +
+                                                alpha * statev(12) * statev(12) * (w2 + h2)));
+            statev(9) = std::sqrt(statev(9) * statev(9) +
+                                  (statev(16) * statev(16) / w2 + statev(17) * statev(17) / h2 +
+                                   statev(15) * statev(15) / (w2 + h2) / alpha) / multiplier);
 		}
 	}
 	else {
@@ -189,8 +197,8 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		statev(3) = mstress[0];
 		statev(4) = mstress[1];
 		statev(5) = mstress[2];
-		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account? This differs from the Overleaf formulation!
-		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account? This differs from the Overleaf formulation!
+		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2)));
+		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha);
 		statev(10) = Wint + statev(10);
 		statev(11) = w;
 		
@@ -210,6 +218,13 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 			statev(15) = mcouple[0];
 			statev(16) = mcouple[1];
 			statev(17) = mcouple[2];
+            // TODO: below is temporary just to fix the bugs from improperly defined effective strain / stress. Will refactor later
+            statev(8) = std::sqrt(statev(8) * statev(8) +
+                                  multiplier * (statev(13) * statev(13) * w2 + statev(14) * statev(14) * h2 +
+                                                alpha * statev(12) * statev(12) * (w2 + h2)));
+            statev(9) = std::sqrt(statev(9) * statev(9) +
+                                  (statev(16) * statev(16) / w2 + statev(17) * statev(17) / h2 +
+                                   statev(15) * statev(15) / (w2 + h2) / alpha) / multiplier);
 		}
 		
 	}else{

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -136,12 +136,12 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 
-		statev(0) = mstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
-		statev(1) = mstrain[1]; //           If you unload to exactly zero (like in the unit tests)
-		statev(2) = mstrain[2]; //           you go to the `else` branch and the state variables do not get updated
-		statev(3) = mstress[0]; //           while a loading step did happen!
-		statev(4) = mstress[1]; //           I am leaving this as is for now because we will refactor this in depth soon!
-		statev(5) = mstress[2]; //           The current fix aims to retrieve the "old" behavior
+		statev(0) = mstrain[0] + eigenstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
+		statev(1) = mstrain[1] + eigenstrain[1]; //           If you unload to exactly zero (like in the unit tests)
+		statev(2) = mstrain[2] + eigenstrain[2]; //           you go to the `else` branch and the state variables do not get updated
+		statev(3) = mstress[0];                  //           while a loading step did happen!
+		statev(4) = mstress[1];                  //           I am leaving this as is for now because we will refactor this in depth soon!
+		statev(5) = mstress[2];                  //           The current fix aims to retrieve the "old" behavior
 		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account? This differs from the Overleaf formulation!
 		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account? This differs from the Overleaf formulation!
 		statev(10) = Wint + statev(10);
@@ -183,9 +183,9 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 		
-		statev(0) = mstrain[0]+ eigenstrain[0]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
-		statev(1) = mstrain[1]+ eigenstrain[1]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
-		statev(2) = mstrain[2]+ eigenstrain[2]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
+		statev(0) = mstrain[0] + eigenstrain[0];
+		statev(1) = mstrain[1] + eigenstrain[1];
+		statev(2) = mstrain[2] + eigenstrain[2];
 		statev(3) = mstress[0];
 		statev(4) = mstress[1];
 		statev(5) = mstress[2];

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -136,14 +136,14 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 
-		statev(0) = mstrain[0];
-		statev(1) = mstrain[1];
-		statev(2) = mstrain[2];
-		statev(3) = mstress[0];
-		statev(4) = mstress[1];
-		statev(5) = mstress[2];
-		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account?
-		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account?
+		statev(0) = mstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
+		statev(1) = mstrain[1]; //           If you unload to exactly zero (like in the unit tests)
+		statev(2) = mstrain[2]; //           you go to the `else` branch and the state variables do not get updated
+		statev(3) = mstress[0]; //           while a loading step did happen!
+		statev(4) = mstress[1]; //           I am leaving this as is for now because we will refactor this in depth soon!
+		statev(5) = mstress[2]; //           The current fix aims to retrieve the "old" behavior
+		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account? This differs from the Overleaf formulation!
+		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account? This differs from the Overleaf formulation!
 		statev(10) = Wint + statev(10);
 		statev(11) = w;
 		//
@@ -189,8 +189,8 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		statev(3) = mstress[0];
 		statev(4) = mstress[1];
 		statev(5) = mstress[2];
-		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); 
-		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha);
+		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2))); // TODO JBC: Why doesn't statev(8) take bending into account? This differs from the Overleaf formulation!
+		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha); // TODO JBC: Why doesn't statev(9) take bending into account? This differs from the Overleaf formulation!
 		statev(10) = Wint + statev(10);
 		statev(11) = w;
 		

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,7 +49,7 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature,double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
     	ChVector3d mstrain;
     	ChVector3d mcurvature;	
 	//
@@ -61,7 +61,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		E0=E0*random_field;
 	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
 	// 	
-	mstrain=statev.segment(0,3)+dmstrain.eigen();	
+	mstrain=statev.segment(0,3)+dmstrain.eigen()-eigenstrain.eigen();
 	//	
 	//
 	double epsQ, epsQN;
@@ -100,6 +100,8 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 	//
 	if (epsQ != 0) {
 		if (mstrain[0] > 10e-16 || sigmat<sigmac) {     // fracture behaivor
+             // TODO JBC: test for sigmat<sigmac is currently debated
+             //           and was not present in the eigenstrain version of that function before this refactoring
 			double strsQ = FractureBC(mstrain, random_field, len, epsQ, epsQN, epsT, statev);
 			mstress[0] = strsQ * mstrain[0] / epsQ;
 			mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
@@ -181,9 +183,9 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 		
-		statev(0) = mstrain[0];
-		statev(1) = mstrain[1];
-		statev(2) = mstrain[2];
+		statev(0) = mstrain[0]+ eigenstrain[0]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
+		statev(1) = mstrain[1]+ eigenstrain[1]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
+		statev(2) = mstrain[2]+ eigenstrain[2]; // TODO JBC: why is the eigenstrain only removed from the state variable in the elastic case ? I think it should be removed in the inelastic case too !
 		statev(3) = mstress[0];
 		statev(4) = mstress[1];
 		statev(5) = mstress[2];
@@ -323,182 +325,6 @@ void ChWoodMaterialVECT::ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& 
     }
 }
 */
-
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature, ChVectorDynamic<>& eigenstrain ,double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {  
-    	ChVector3d mstrain;
-    	ChVector3d mcurvature;	
-	//
-	double E0=this->Get_E0();
-	double alpha=this->Get_alpha();	
-	if (random_field)
-		E0=E0*random_field;
-	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
-	// 	
-	mstrain=statev.segment(0,3)+dmstrain.eigen()-eigenstrain;	
-	//	
-	//
-	double epsQ, epsQN;
-	double epsT;
-	double h2=height*height;		
-	double w2=width*width;
-	
-	if (!this->GetCoupleMultiplier()){		
-		epsQ = std::sqrt(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]));
-		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]);
-	}else{	
-		double multiplier=this->GetCoupleMultiplier()/3.;					
-		mcurvature=statev.segment(12,3)+dmcurvature.eigen();
-		//std::cout<<"mstrain: "<<mstrain<<" mcurvature: "<<mcurvature<<std::endl;
-		//std::cout<<"curvature: "<<mcurvature<<std::endl;		
-				
-		epsQ = std::sqrt(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2])+
-					multiplier*(alpha*mcurvature[0]*mcurvature[0]*(w2+h2)+ mcurvature[1]*mcurvature[1]*w2+
-					mcurvature[2]*mcurvature[2]*h2));
-		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]+multiplier*mcurvature[0]*mcurvature[0]*(w2+h2));
-	
-	}
-	
-	if (statev(6) < mstrain[0]) {
-		statev(6) = mstrain[0];
-	}
-	if (statev(7) < epsT) {
-		statev(7) = epsT;
-	}
-	
-	
-	if (!GetElasticAnalysisFlag()) {
-	//
-	// INELASTIC ANALYSIS
-	//
-	if (epsQ != 0) {
-		if (mstrain[0] > 10e-16) {     // fracture behaivor
-			double strsQ = FractureBC(mstrain, random_field, len, epsQ, epsQN, epsT, statev);
-			mstress[0] = strsQ * mstrain[0] / epsQ;
-			mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
-			mstress[2] = alpha * strsQ * mstrain[2] / epsQ;
-			//
-			if(this->GetCoupleMultiplier()){
-				double multiplier=this->GetCoupleMultiplier()/3.;
-				mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-				mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-				mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
-			}
-		}
-		else {
-			
-			 double strsQ = CompressBC(mstrain, random_field, len, epsQ, epsT, epsQN, statev);;
-			 
-			 mstress[0] = strsQ * mstrain[0] / epsQ;
-			 mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
-			 mstress[2] = alpha * strsQ * mstrain[2] / epsQ;
-			 //
-			 if(this->GetCoupleMultiplier()){
-				 double multiplier=this->GetCoupleMultiplier()/3.;
-				 mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-				 mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-				 mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
-			 }
-		}
-		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
-		double w_N = len * (mstrain[0] - mstress[0] / E0);
-		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
-		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
-
-		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
-
-		
-		statev(8) = std::sqrt(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2])); 
-		statev(9) = std::sqrt(mstress[0] * mstress[0] + (mstress[1] * mstress[1] + mstress[2] * mstress[2]) / alpha);		
-		statev(10) = Wint + statev(10);
-		statev(11) = w;
-		
-		statev(0) = mstrain[0];
-		statev(1) = mstrain[1];
-		statev(2) = mstrain[2];
-		statev(3) = mstress[0];
-		statev(4) = mstress[1];
-		statev(5) = mstress[2];
-		//
-		if(this->GetCoupleMultiplier()){				
-				statev(12) = mcurvature[0];
-				statev(13) = mcurvature[1];
-				statev(14) = mcurvature[2];	
-				//
-				statev(15) = mcouple[0];
-				statev(16) = mcouple[1];
-				statev(17) = mcouple[2];
-		}
-	}
-	else {
-		mstress.Set(0.0);
-		mcouple.Set(0.0);
-	}
-	//std::cout << "stress: " << mstress << std::endl;
-	//std::cout << statev(3) << ' ' << statev(4) << ' ' << statev(5) << ' ' << statev(0) << ' ' << statev(1) << ' ' << statev(2) << std::endl;
-	
-	}else{
-	
-	//
-	// ELASTIC ANALYSIS
-	//
-	if (epsQ!=0) {
-	    double strsQ=E0*epsQ;
-		mstress[0]=strsQ*mstrain[0]/epsQ;
-		mstress[1]=alpha*strsQ*mstrain[1]/epsQ;
-		mstress[2]=alpha*strsQ*mstrain[2]/epsQ;		
-		
-		
-		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
-		double w_N = len * (mstrain[0] - mstress[0] / E0);
-		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
-		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
-
-		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
-		
-		
-		statev(8) = std::sqrt(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2])); 
-		statev(9) = std::sqrt(mstress[0] * mstress[0] + (mstress[1] * mstress[1] + mstress[2] * mstress[2]) / alpha);
-		statev(10) = Wint + statev(10);
-		statev(11) = w;
-		
-		statev(0) = mstrain[0]+eigenstrain(0);
-		statev(1) = mstrain[1]+eigenstrain(1);
-		statev(2) = mstrain[2]+eigenstrain(2);
-		statev(3) = mstress[0];
-		statev(4) = mstress[1];
-		statev(5) = mstress[2];
-		
-		
-		if(this->GetCoupleMultiplier()){
-			double multiplier=this->GetCoupleMultiplier()/3.;
-			mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-			mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-			mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;
-			//
-			statev(12) = mcurvature[0];
-			statev(13) = mcurvature[1];
-			statev(14) = mcurvature[2];
-			//std::cout<<"mcurvature: "<<mcurvature.x()<<"\t"<<mcurvature.y()<<"\t"<<mcurvature.z()<<std::endl;
-			//std::cout<<"mcouple: "<<mcouple.x()<<"\t"<<mcouple.y()<<"\t"<<mcouple.z()<<std::endl;
-			//
-			statev(15) = mcouple[0];
-			statev(16) = mcouple[1];
-			statev(17) = mcouple[2];
-		}
-		
-	}else{
-		mstress.Set(0.0);
-		mcouple.Set(0.0);
-		//statev.setZero();		
-	}
-	
-	}
-	
-	//std::cout<<"mstress: "<<mstress<<"  mcouple: "<<mcouple<<" w2, h2 "<<w2<<" "<<h2<<std::endl;
-	//if (mstrain[0]<0) 
-	//	exit(1);
-	//printf("Statev: %f, %f, %f, %f, %f, %f\n",statev(0), statev(1), statev(2), statev(3), statev(4), statev(5));
-}
 
 
 

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -105,10 +105,9 @@ class ChWoodApi ChWoodMaterialVECT {
     double GetCoupleContrib2EquStrainFlag() const { return m_CoupleContrib2EquStrain; }
     void SetCoupleContrib2EquStrainFlag(double CoupleContrib2EquStrain) { m_CoupleContrib2EquStrain = CoupleContrib2EquStrain; }	
     /// Compute stresses from given strains and state variables.
-    void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+    void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     //void ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& curvature_incr, double &length, StateVarVector& statev, double& width, double& height, double& random_field, ChVector3d& stress, ChVector3d& surfacic_couple);
     //
-	void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, ChVectorDynamic<>& eigenstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     
     double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev);
 

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -74,7 +74,8 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     ChVector3d stress;
     ChVector3d couple;
     double random_field = 1.0; // NO RANDOM FIELD
-    my_mat->ComputeStress(strain,curvature, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+    ChVector3d eigeinstrain(0.0); // NO EIGENSTRAIN
+    my_mat->ComputeStress(strain, curvature, eigeinstrain, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
 
 }
 


### PR DESCRIPTION
This PR combines the 2 CBL connectors stress functions, where one took eigenstrain as an input and the other one did not.

These two functions were nearly identical and the code duplication caused confusion and was error prone. We only have 1 function now, which is given zero eigenstrain in case no eigenstrain is used. The type has also been change dfrom dynamic to static vector since we know the size of the eigenstrain at compile time (3).

This PR also fixes a bug in the function which took eigenstain as input, where variable `epsQN` was passed uninitialized to the `fractureBC` and `compressBC` functions, leading to undefined behavior.


there are still open theoretical questions on this PR I would like to have answered:
1. why is eigenstrain removed from the strain state variables only in the elastic case? I believe it should also be the case in the inelastic case and we should modify this.
2. The effective strain and stress in `statev(8)` and `statev(9)` respectively, do not take into account the curvatures and the moments, which is different from the Overleaf formulation. Why is that? Should we modify it?



Thank you