### PR TITLE
Refactor strain calculation and create old/new state variables in CBL connector element

### DIFF
--- a/src/chrono_wood/ChBeamSectionCBLCON.cpp
+++ b/src/chrono_wood/ChBeamSectionCBLCON.cpp
@@ -36,10 +36,12 @@ ChBeamSectionCBLCON::ChBeamSectionCBLCON( std::shared_ptr<ChWoodMaterialVECT> ma
                                        )
     : m_material{material}, m_area{area}, m_center{center}, m_facetFrame{facetFrame} {
         m_state.setZero();
+        m_state_new.setZero();
 }
 
 ChBeamSectionCBLCON::ChBeamSectionCBLCON() {
 	m_state.setZero();
+    m_state_new.setZero();
 };
 
 ChBeamSectionCBLCON::~ChBeamSectionCBLCON() {};

--- a/src/chrono_wood/ChBeamSectionCBLCON.h
+++ b/src/chrono_wood/ChBeamSectionCBLCON.h
@@ -91,6 +91,7 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
   
     StateVarVector  Get_StateVar() const { return m_state; };
     void Set_StateVar(StateVarVector  state) { m_state=state; }
+    void Set_StateVarNew(StateVarVector  state) { m_state_new=state; }
     
     enum ConSectionType { transverse_regular_bot, transverse_regular_gen, transverse_regular_top, longitudinal, tangential_ray_bot, tangential_ray_gen, tangential_ray_top, radial_ray_bot, radial_ray_gen, radial_ray_top};
     
@@ -116,6 +117,8 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
 	
 	ChVector3d Get_nonMechanicStrain() const { return m_nonMechanicStrain; };
     void Set_nonMechanicStrain(ChVector3d nonMechanicStrain) { m_nonMechanicStrain=nonMechanicStrain; }
+
+    void UpdateStateVariables() { m_state = m_state_new; }
     
     
   protected:
@@ -123,6 +126,7 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
     ChVector3d m_center;
     ChMatrix33<double> m_facetFrame;
     StateVarVector m_state;
+    StateVarVector m_state_new;
 	ChVector3d  m_nonMechanicStrain;
     //std::shared_ptr<ChInternalDataCSL> m_state;  
     double mcon_width=1.0;  

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -727,18 +727,37 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     ChVector3d mstrain;
     ChVector3d mcouple;
     ChVector3d curvature;
-    StateVarVector statev;
+
     this->ComputeStrain(dofs, mstrain, curvature);
-    statev=mysection->Get_StateVar();
     double width=mysection->GetWidth()/2;
     double height=mysection->GetHeight()/2;
     double random_field =mysection->GetRandomField();
-
     auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
-    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
+    StateVarVector statev_old = mysection->Get_StateVar();
+    StateVarVector statev_new;
+    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statev_old, statev_new, area, width, height, random_field, mstress, mcouple);
 
+    mysection->Set_StateVarNew(statev_new);
 
-    mysection->Set_StateVar(statev);
+    // Code below replicates current behavior: updates state variables at every call to ComputeInternalForces, which is incorrect!
+    // TODO: to update at every step, we will need to call the function below (or equivalent, at the end of every step).
+    //       The Element has no idea how the timestepper operates, so we would have to do this outside of this Class.
+    //       and requires modifications to the base parent classes for the elements, and Chrono timestepper behavior.
+    //
+    //       A quick and dirty way to do this for now is to manually update the state variables inside the "run step" loop in the `main()` function of our compiled demos, e.g.:
+    // 
+    //          while (sys.GetChTime() < duration) {
+    //              sys.DoStepDynamics(timestep);
+    //              for (auto& element : my_mesh->GetElements()) {
+    //                  if (auto connector = std::dynamic_pointer_cast<ChElementCBLCON>(element)) {
+    //                      connector->GetSection()->UpdateStateVariables();
+    //                  }
+    //              }
+    //          }
+    // 
+    // 
+
+    mysection->Set_StateVar(statev_new);
 
     ChVector3d force = area * (nmL_tr * mstress);
     ChVector3d xc_xi;

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -262,30 +262,6 @@ void ChElementCBLCON::ComputeStrainIncrement(ChVectorN<double, 12>& displ_incr, 
 
 
 
-// TODO: this is not used consider deleting
-void ChElementCBLCON::ComputeStress(ChVector3d& mstress) {
-    ChVector3d mstrain;
-    ChVector3d curvature;
-    // Displacement and rotation increment of nodes:
-    this->ComputeStrainIncrement(dofs_increment, mstrain, curvature);
-    //std::cout<<"\nmstrain:\n"<<mstrain<<std::endl;
-    //
-    double E0=this->section-> Get_material()->Get_E0();
-    double alpha=this->section-> Get_material()->Get_alpha();
-    //
-    double epsQ=pow(mstrain[0]*mstrain[0]+alpha*(mstrain[1]*mstrain[1]+mstrain[2]*mstrain[2]), 0.5);
-    double strsQ=E0*epsQ;
-    //
-    if (epsQ!=0) {
-        mstress[0]=strsQ*mstrain[0]/epsQ;
-        mstress[1]=alpha*strsQ*mstrain[1]/epsQ;
-        mstress[2]=alpha*strsQ*mstrain[2]/epsQ;
-    }else{
-        mstress.Set(0.0);
-    }
-}
-
-
 void ChElementCBLCON::ComputeMmatrixGlobal(ChMatrixRef M) {
     // Mass Matrix
 

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -755,8 +755,7 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     //              }
     //          }
     // 
-    // 
-
+    // Comment line below and add code above to your CBL demo to implement update at end of step only
     mysection->Set_StateVar(statev_new);
 
     ChVector3d force = area * (nmL_tr * mstress);

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -30,6 +30,7 @@
 #include <ostream>
 #include "chrono/core/ChMatrix.h"
 #include "chrono/core/ChMatrix33.h"
+#include "chrono/core/ChQuaternion.h"
 #include "chrono/core/ChVector3.h"
 
 namespace chrono {
@@ -172,24 +173,26 @@ void ChElementCBLCON::GetStateBlock(ChVectorDynamic<>& mD) {
     // If large deflection disabled, return displacement in global frame
     // TODO: Go back to this function when we decide how to enable and formulate large deflection
     auto getDisplacement = [&](std::shared_ptr<ChNodeFEAxyzrot> node) {
-        ChVector3d local_disp;
+        ChVector3d global_disp;
         if (!LargeDeflection)
-            local_disp = node->Frame().GetPos() - node->GetX0().GetPos();
+            global_disp = node->Frame().GetPos() - node->GetX0().GetPos();
         else
-            local_disp = node->Frame().GetPos() - node->GetX0().GetPos(); // TODO: temporary
-        return local_disp;
+            global_disp = node->Frame().GetPos() - node->GetX0().GetPos(); // TODO: temporary
+        return global_disp;
     };
 
     // Node rotations
     // If Large deflection disabled, return rotation in global frame
     // TODO: Go back to this function when we decide how to enable and formulate large deflection
     auto getRotation = [&](std::shared_ptr<ChNodeFEAxyzrot> node) {
+        ChQuaternion<> global_dq = node->Frame().GetRot() * node->GetX0().GetRot().GetConjugate();
         ChVector3d delta_rot_dir;
         double delta_rot_angle;
+
         if (!LargeDeflection)
-            node->Frame().GetRot().GetAngleAxis(delta_rot_angle, delta_rot_dir);
+            global_dq.GetAngleAxis(delta_rot_angle, delta_rot_dir);
         else
-            node->Frame().GetRot().GetAngleAxis(delta_rot_angle, delta_rot_dir); // TODO: temporary
+            global_dq.GetAngleAxis(delta_rot_angle, delta_rot_dir); // TODO: temporary
         // TODO: GetAngleAxis already returns in the range [-PI..PI], no need to change range
         // TODO: the previous range was only shifted if delta_rot_angle > CH_PI. How about delta_rot_angle < - CH_PI ? Was that a bug?
         // TODO: We may want to use GetRotVec directly, but the angle is not within [-PI .. PI]
@@ -222,12 +225,12 @@ void ChElementCBLCON::GetField_dt(ChVectorDynamic<>& mD_dt) {
 }
 
 
-void ChElementCBLCON::ComputeStrainIncrement(ChVectorN<double, 12>& displ_incr, ChVector3d& mstrain, ChVector3d& curvature) {
+void ChElementCBLCON::ComputeStrain(ChVectorN<double, 12>& displ, ChVector3d& mstrain, ChVector3d& curvature) {
     //
-    ChVector3d ui = displ_incr.segment(0,3);
-    ChVector3d ri = displ_incr.segment(3,3);
-    ChVector3d uj = displ_incr.segment(6,3);
-    ChVector3d rj = displ_incr.segment(9,3);
+    ChVector3d ui = displ.segment(0,3);
+    ChVector3d ri = displ.segment(3,3);
+    ChVector3d uj = displ.segment(6,3);
+    ChVector3d rj = displ.segment(9,3);
     ChVector3d xc_xi;
     ChVector3d xc_xj;
     double linv = 1.0 / this->length;
@@ -482,12 +485,6 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
     //
     this->UpdateRotation();
     //
-    // Initialize total displacement increment
-    //
-    ChVectorDynamic<> displ(12);
-    this->GetStateBlock(displ);
-    dofs_old=displ;
-    //
     // Initiliaze state variables:
     //
     // All state variables initialized at zero, which is the value in the Section constructor
@@ -707,11 +704,10 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     assert(Fi.size() == 12);
     assert(section);
 
-    // Displacement and rotation increment of nodes:
+    // Displacement and rotation of nodes:
     ChVectorDynamic<> displ(12);
-    this->GetStateBlock(displ);
-    dofs_increment = displ - dofs_old; // TODO JBC: Rotations are not additive, in general this is wrong for rotation DOFS and the approximation only holds for infinitesimal rotations, with error ~ angle !
-    dofs_old = displ;
+    this->GetStateBlock(displ); // TODO: bad Chrono design, there is no reason for that function to exist in higher-level parent with dynamic vector since it is never used outside of element. Each element should decide how to handle their DOFS
+    ChVectorN<double, 12> dofs = displ;
 
     //
     // Get facet area and length of beam
@@ -728,18 +724,18 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
 
     auto mysection=this->section;
     ChVector3d mstress;
-    ChVector3d dmstrain;
+    ChVector3d mstrain;
     ChVector3d mcouple;
-    ChVector3d dcurvature;
+    ChVector3d curvature;
     StateVarVector statev;
-    this->ComputeStrainIncrement(dofs_increment, dmstrain, dcurvature);
+    this->ComputeStrain(dofs, mstrain, curvature);
     statev=mysection->Get_StateVar();
     double width=mysection->GetWidth()/2;
     double height=mysection->GetHeight()/2;
     double random_field =mysection->GetRandomField();
 
     auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
-    mysection->Get_material()->ComputeStress( dmstrain, dcurvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
+    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statev, area, width, height, random_field, mstress, mcouple);
 
 
     mysection->Set_StateVar(statev);

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -153,7 +153,7 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 	///
 	/// Compute strain at a CBLCON facet 
 	///
-	void ComputeStrainIncrement(ChVectorN<double, 12>& displ_incr, ChVector3d& mStrain, ChVector3d& curvature);
+	void ComputeStrain(ChVectorN<double, 12>& displ, ChVector3d& mStrain, ChVector3d& curvature);
 	///
 	///
 	///	
@@ -327,9 +327,6 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 
     ChQuaternion<> q_element_abs_rot;
     ChQuaternion<> q_element_ref_rot;
-    
-    ChVectorN<double, 12> dofs_increment;
-    ChVectorN<double, 12> dofs_old;
 
     bool disable_corotate;
     bool force_symmetric_stiffness;

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -156,10 +156,6 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 	void ComputeStrainIncrement(ChVectorN<double, 12>& displ_incr, ChVector3d& mStrain, ChVector3d& curvature);
 	///
 	///
-	/// Compute stress at a CBLCON facet . TODO : seems unused
-	///
-	void ComputeStress(ChVector3d& mstress);
-	///
 	///	
 	virtual void ComputeMmatrixGlobal(ChMatrixRef M) override;
     /// Computes the local (material) stiffness matrix of the element:

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,9 +49,12 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
     	ChVector3d mstrain;
-    	ChVector3d mcurvature;	
+    	ChVector3d mcurvature;
+
+        ChVector3d dmstrain;
+    	ChVector3d dmcurvature;
 	//
 	double E0=this->Get_E0();
 	double alpha=this->Get_alpha();	
@@ -61,7 +64,8 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		E0=E0*random_field;
 	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
 	// 	
-	mstrain=statev.segment(0,3)+dmstrain.eigen()-eigenstrain.eigen();
+	mstrain = strain.eigen() - eigenstrain.eigen();
+    dmstrain = strain - statev.segment(0,3);
 	//	
 	//
 	double epsQ, epsQN;
@@ -75,9 +79,8 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& dmstrain, ChVector3d& dmcurva
 		epsQN = mstrain[0];
 	}else{	
 		double multiplier=this->GetCoupleMultiplier()/3.;
-		mcurvature=statev.segment(12,3)+dmcurvature.eigen();
-		//std::cout<<"mstrain: "<<mstrain<<" mcurvature: "<<mcurvature<<std::endl;
-		//std::cout<<"curvature: "<<mcurvature<<std::endl;		
+        mcurvature = curvature; // TODO: no eigencurvature ?
+		dmcurvature = curvature - statev.segment(12,3);
 				
 		epsQN = std::sqrt(mstrain[0] * mstrain[0] + multiplier*( mcurvature[1]*mcurvature[1]*w2 + mcurvature[2]*mcurvature[2]*h2));
 		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]+multiplier*mcurvature[0]*mcurvature[0]*(w2+h2));

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,7 +49,7 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev_old, StateVarVector& statev_new,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
     	ChVector3d mstrain;
     	ChVector3d mcurvature;
 
@@ -65,7 +65,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
 	// 	
 	mstrain = strain.eigen() - eigenstrain.eigen();
-    dmstrain = strain - statev.segment(0,3);
+    dmstrain = strain - statev_old.segment(0,3); // Increment of strain over the current step so far !!! Not over the current iteration
 	//	
 	//
 	double epsQ, epsQN;
@@ -80,7 +80,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	}else{	
 		double multiplier=this->GetCoupleMultiplier()/3.;
         mcurvature = curvature; // TODO: no eigencurvature ?
-		dmcurvature = curvature - statev.segment(12,3);
+		dmcurvature = curvature - statev_old.segment(12,3); // Increment of curvature over the current step so far !!! Not over the current iteration
 				
 		epsQN = std::sqrt(mstrain[0] * mstrain[0] + multiplier*( mcurvature[1]*mcurvature[1]*w2 + mcurvature[2]*mcurvature[2]*h2));
 		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]+multiplier*mcurvature[0]*mcurvature[0]*(w2+h2));
@@ -89,12 +89,18 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	
 	}
 	
-	if (statev(6) < epsQN) {
-		statev(6) = epsQN;
-	}
-	if (statev(7) < epsT) {
-		statev(7) = epsT;
-	}
+	if (statev_old(6) < epsQN) {
+		statev_new(6) = epsQN;
+	} else {
+        statev_new(6) = statev_old(6);
+    }
+	if (statev_old(7) < epsT) {
+		statev_new(7) = epsT;
+	} else {
+        statev_new(7) = statev_old(7);
+    }
+
+    double eps_max = std::sqrt(statev_new(6) * statev_new(6) + alpha * statev_new(7) * statev_new(7));
 	
 	
 	if (!GetElasticAnalysisFlag()) {
@@ -105,7 +111,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 		if (mstrain[0] > 10e-16 || sigmat<sigmac) {     // fracture behaivor
              // TODO JBC: test for sigmat<sigmac is currently debated
              //           and was not present in the eigenstrain version of that function before this refactoring
-			double strsQ = FractureBC(mstrain, random_field, len, epsQ, epsQN, epsT, statev);
+			double strsQ = FractureBC(mstrain, random_field, len, epsQ, epsQN, epsT, statev_old, eps_max);
 			mstress[0] = strsQ * mstrain[0] / epsQ;
 			mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
 			mstress[2] = alpha * strsQ * mstrain[2] / epsQ;
@@ -119,7 +125,7 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 		}
 		else {
 			
-			 double strsQ = CompressBC(mstrain, random_field, len, epsQ, epsT, epsQN, statev);
+			 double strsQ = CompressBC(mstrain, random_field, len, epsQ, epsT, epsQN, statev_old);
 			 
 			 mstress[0] = strsQ * mstrain[0] / epsQ;
 			 mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
@@ -132,40 +138,40 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 				 mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
 			 }
 		}
-		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
+		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dmcurvature[2]);
 		double w_N = len * (mstrain[0] - mstress[0] / E0);
 		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
 		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 
-		statev(0) = mstrain[0] + eigenstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
-		statev(1) = mstrain[1] + eigenstrain[1]; //           If you unload to exactly zero (like in the unit tests)
-		statev(2) = mstrain[2] + eigenstrain[2]; //           you go to the `else` branch and the state variables do not get updated
-		statev(3) = mstress[0];                  //           while a loading step did happen!
-		statev(4) = mstress[1];                  //           I am leaving this as is for now because we will refactor this in depth soon!
-		statev(5) = mstress[2];                  //           The current fix aims to retrieve the "old" behavior
-        statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2)));
-        statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha);
-        statev(10) = Wint + statev(10);
-		statev(11) = w;
+		statev_new(0) = mstrain[0] + eigenstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
+		statev_new(1) = mstrain[1] + eigenstrain[1]; //           If you unload to exactly zero (like in the unit tests)
+		statev_new(2) = mstrain[2] + eigenstrain[2]; //           you go to the `else` branch and the state variables do not get updated
+		statev_new(3) = mstress[0];                  //           while a loading step did happen!
+		statev_new(4) = mstress[1];                  //           I am leaving this as is for now because we will refactor this in depth soon!
+		statev_new(5) = mstress[2];                  //           The current fix aims to retrieve the "old" behavior
+        statev_new(8) = std::sqrt(statev_new(0) * statev_new(0) + alpha * (statev_new(1) * statev_new(1) + statev_new(2) * statev_new(2)));
+        statev_new(9) = std::sqrt(statev_new(3) * statev_new(3) + (statev_new(4) * statev_new(4) + statev_new(5) * statev_new(5)) / alpha);
+        statev_new(10) = Wint + statev_old(10);
+		statev_new(11) = w;
 		//
 		if(this->GetCoupleMultiplier()){
-            statev(12) = mcurvature[0];
-            statev(13) = mcurvature[1];
-            statev(14) = mcurvature[2];
+            statev_new(12) = mcurvature[0];
+            statev_new(13) = mcurvature[1];
+            statev_new(14) = mcurvature[2];
             //
-            statev(15) = mcouple[0];
-            statev(16) = mcouple[1];
-            statev(17) = mcouple[2];
+            statev_new(15) = mcouple[0];
+            statev_new(16) = mcouple[1];
+            statev_new(17) = mcouple[2];
             // TODO: below is temporary just to fix the bugs from improperly defined effective strain / stress. Will refactor later
             double multiplier=this->GetCoupleMultiplier()/3.;
-            statev(8) = std::sqrt(statev(8) * statev(8) +
-                                  multiplier * (statev(13) * statev(13) * w2 + statev(14) * statev(14) * h2 +
-                                                alpha * statev(12) * statev(12) * (w2 + h2)));
-            statev(9) = std::sqrt(statev(9) * statev(9) +
-                                  (statev(16) * statev(16) / w2 + statev(17) * statev(17) / h2 +
-                                   statev(15) * statev(15) / (w2 + h2) / alpha) / multiplier);
+            statev_new(8) = std::sqrt(statev_new(8) * statev_new(8) +
+                                      multiplier * (statev_new(13) * statev_new(13) * w2 + statev_new(14) * statev_new(14) * h2 +
+                                                    alpha * statev_new(12) * statev_new(12) * (w2 + h2)));
+            statev_new(9) = std::sqrt(statev_new(9) * statev_new(9) +
+                                      (statev_new(16) * statev_new(16) / w2 + statev_new(17) * statev_new(17) / h2 +
+                                       statev_new(15) * statev_new(15) / (w2 + h2) / alpha) / multiplier);
 		}
 	}
 	else {
@@ -187,23 +193,23 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 		mstress[2]=alpha*strsQ*mstrain[2]/epsQ;		
 		
 		
-		double Wint = len * area * (((mstress[0] + statev(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev(17)) / 2.0) * dmcurvature[2]);
+		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dmcurvature[2]);
 		double w_N = len * (mstrain[0] - mstress[0] / E0);
 		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
 		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 		
-		statev(0) = mstrain[0] + eigenstrain[0];
-		statev(1) = mstrain[1] + eigenstrain[1];
-		statev(2) = mstrain[2] + eigenstrain[2];
-		statev(3) = mstress[0];
-		statev(4) = mstress[1];
-		statev(5) = mstress[2];
-		statev(8) = std::sqrt(statev(0) * statev(0) + alpha * (statev(1) * statev(1) + statev(2) * statev(2)));
-		statev(9) = std::sqrt(statev(3) * statev(3) + (statev(4) * statev(4) + statev(5) * statev(5)) / alpha);
-		statev(10) = Wint + statev(10);
-		statev(11) = w;
+		statev_new(0) = mstrain[0] + eigenstrain[0];
+		statev_new(1) = mstrain[1] + eigenstrain[1];
+		statev_new(2) = mstrain[2] + eigenstrain[2];
+		statev_new(3) = mstress[0];
+		statev_new(4) = mstress[1];
+		statev_new(5) = mstress[2];
+		statev_new(8) = std::sqrt(statev_new(0) * statev_new(0) + alpha * (statev_new(1) * statev_new(1) + statev_new(2) * statev_new(2)));
+		statev_new(9) = std::sqrt(statev_new(3) * statev_new(3) + (statev_new(4) * statev_new(4) + statev_new(5) * statev_new(5)) / alpha);
+		statev_new(10) = Wint + statev_old(10);
+		statev_new(11) = w;
 		
 		
 		if(this->GetCoupleMultiplier()){
@@ -212,22 +218,22 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 			mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
 			mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;
 			//
-			statev(12) = mcurvature[0];
-			statev(13) = mcurvature[1];
-			statev(14) = mcurvature[2];
+			statev_new(12) = mcurvature[0];
+			statev_new(13) = mcurvature[1];
+			statev_new(14) = mcurvature[2];
 			//std::cout<<"mcurvature: "<<mcurvature.x()<<"\t"<<mcurvature.y()<<"\t"<<mcurvature.z()<<std::endl;
 			//std::cout<<"mcouple: "<<mcouple.x()<<"\t"<<mcouple.y()<<"\t"<<mcouple.z()<<std::endl;
 			//
-			statev(15) = mcouple[0];
-			statev(16) = mcouple[1];
-			statev(17) = mcouple[2];
+			statev_new(15) = mcouple[0];
+			statev_new(16) = mcouple[1];
+			statev_new(17) = mcouple[2];
             // TODO: below is temporary just to fix the bugs from improperly defined effective strain / stress. Will refactor later
-            statev(8) = std::sqrt(statev(8) * statev(8) +
-                                  multiplier * (statev(13) * statev(13) * w2 + statev(14) * statev(14) * h2 +
-                                                alpha * statev(12) * statev(12) * (w2 + h2)));
-            statev(9) = std::sqrt(statev(9) * statev(9) +
-                                  (statev(16) * statev(16) / w2 + statev(17) * statev(17) / h2 +
-                                   statev(15) * statev(15) / (w2 + h2) / alpha) / multiplier);
+            statev_new(8) = std::sqrt(statev_new(8) * statev_new(8) +
+                                      multiplier * (statev_new(13) * statev_new(13) * w2 + statev_new(14) * statev_new(14) * h2 +
+                                                    alpha * statev_new(12) * statev_new(12) * (w2 + h2)));
+            statev_new(9) = std::sqrt(statev_new(9) * statev_new(9) +
+                                      (statev_new(16) * statev_new(16) / w2 + statev_new(17) * statev_new(17) / h2 +
+                                       statev_new(15) * statev_new(15) / (w2 + h2) / alpha) / multiplier);
 		}
 		
 	}else{
@@ -349,7 +355,7 @@ void ChWoodMaterialVECT::ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& 
 
 
 
-double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev) {
+double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev, double eps_max) {
 	//
 	double E0 = this->Get_E0();
 	double alpha = this->Get_alpha();
@@ -389,10 +395,9 @@ double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field,
 	double Ht = 2 * E0 / (lt / len - 1);
 	double H0 = Ht * pow(2 * omega / CH_PI, nt);
 
-	double eps_max = std::sqrt(statev(6) * statev(6) + alpha * statev(7) * statev(7));
 	double sigma_bt = sigma0 * exp(-H0 * std::max((eps_max - eps0), 0.0) / sigma0);
 
-	double strs_ela = E0 * (epsQ - statev(8)) + statev(9);
+	double strs_ela = E0 * (epsQ - statev(8)) + statev(9); // The elastic prediction increments from old values. TODO: take this out of this function, not its role
 	double sigma_fr = std::min(std::max(strs_ela, 0.0), sigma_bt);
 	return sigma_fr;
 }
@@ -440,7 +445,7 @@ double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field,
 	
 	
 
-	double strs_ela = E0 * (epsQ - statev(8)) + statev(9); 
+	double strs_ela = E0 * (epsQ - statev(8)) + statev(9);  // The elastic prediction increments from old values. TODO: take this out of this function, not its role
 	double sigma_fr = std::min(std::max(strs_ela, 0.0), sigma_bt);
 	//std::cout<<"epsQ: "<<epsQ<<" epsQ_0: "<<statev(8)<<" sigma_0: "<<statev(9)<<" strs_ela: "<<strs_ela<<"\tsigma_bt: "<<sigma_bt<<"\tsigma_fr: "<<sigma_fr<<std::endl;
 	//exit(9);

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -105,11 +105,11 @@ class ChWoodApi ChWoodMaterialVECT {
     double GetCoupleContrib2EquStrainFlag() const { return m_CoupleContrib2EquStrain; }
     void SetCoupleContrib2EquStrainFlag(double CoupleContrib2EquStrain) { m_CoupleContrib2EquStrain = CoupleContrib2EquStrain; }	
     /// Compute stresses from given strains and state variables.
-    void ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+    void ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev_old, StateVarVector& statev_new, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     //void ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& curvature_incr, double &length, StateVarVector& statev, double& width, double& height, double& random_field, ChVector3d& stress, ChVector3d& surfacic_couple);
     //
     
-    double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev);
+    double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev, double eps_max);
 
 	double CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, StateVarVector& statev);
     

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -105,7 +105,7 @@ class ChWoodApi ChWoodMaterialVECT {
     double GetCoupleContrib2EquStrainFlag() const { return m_CoupleContrib2EquStrain; }
     void SetCoupleContrib2EquStrainFlag(double CoupleContrib2EquStrain) { m_CoupleContrib2EquStrain = CoupleContrib2EquStrain; }	
     /// Compute stresses from given strains and state variables.
-    void ComputeStress(ChVector3d& mstrain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+    void ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     //void ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& curvature_incr, double &length, StateVarVector& statev, double& width, double& height, double& random_field, ChVector3d& stress, ChVector3d& surfacic_couple);
     //
     

--- a/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
@@ -107,7 +107,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Translation of node A
     for (int i = 0; i<3 ; i++) {
         displ_incr(i) = disp; // X, Y, Z direction
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[i], -disp / length);
         ASSERT_DOUBLE_EQ(strain[(i+1)%3], 0.0);
         ASSERT_DOUBLE_EQ(strain[(i+2)%3], 0.0);
@@ -115,7 +115,7 @@ TEST(CBLConnectorTest, compute_strain){
     }
         // XYZ direction
         displ_incr(0) = displ_incr(1) = displ_incr(2) = disp;
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], -disp / length);
         ASSERT_DOUBLE_EQ(strain[1], -disp / length);
         ASSERT_DOUBLE_EQ(strain[2], -disp / length);
@@ -125,7 +125,7 @@ TEST(CBLConnectorTest, compute_strain){
     double dir[3][3] = {{0, 0, 0}, {0, 0, 1}, {0, -1, 0}}; // Direction of vector product: rot x (x_A - X_Center)
     for (int i = 0; i<3 ; i++) {
         displ_incr(3+i) = rot; // X, Y, Z direction
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], rot * center_from_A * dir[i][0]);
         ASSERT_DOUBLE_EQ(strain[1], rot * center_from_A * dir[i][1]);
         ASSERT_DOUBLE_EQ(strain[2], rot * center_from_A * dir[i][2]);
@@ -135,7 +135,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Translation of node B
     for (int i = 0; i<3 ; i++) {
         displ_incr(6+i) = disp; // X, Y, Z direction
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[i], disp / length);
         ASSERT_DOUBLE_EQ(strain[(i+1)%3], 0.0);
         ASSERT_DOUBLE_EQ(strain[(i+2)%3], 0.0);
@@ -143,7 +143,7 @@ TEST(CBLConnectorTest, compute_strain){
     }
         // XYZ direction
         displ_incr(6) = displ_incr(7) = displ_incr(8) = disp;
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], disp / length);
         ASSERT_DOUBLE_EQ(strain[1], disp / length);
         ASSERT_DOUBLE_EQ(strain[2], disp / length);
@@ -153,7 +153,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Direction of vector product: rot x (x_B - X_Center) is the same as for node A
     for (int i = 0; i<3 ; i++) {
         displ_incr(9+i) = rot; // X, Y, Z direction
-        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
+        connector->ComputeStrain(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], rot * (1 - center_from_A) * dir[i][0]);
         ASSERT_DOUBLE_EQ(strain[1], rot * (1 - center_from_A) * dir[i][1]);
         ASSERT_DOUBLE_EQ(strain[2], rot * (1 - center_from_A) * dir[i][2]);
@@ -381,18 +381,7 @@ TEST(CBLConnectorTest, internal_forces){
     // Analytical calculation of the internal forces
     // Equation (12) (13) of https://doi.org/10.1016/j.cemconcomp.2011.02.011
 
-    // TODO JBC: Current rotational DOFs increment calculation inside ComputeInternalForces() is additive in terms of rotation vector
-    // Multiplicative composition of quaternion/rotation matrices, which is exact, does not give the same result:
-    // If the increment of rotation is given by the quaternion dq, then q2 = dq * q1. The increment rotation vector is RotVec(dq)
-    // However, RotVec(q2) - RotVec(q1) != RotVec(dq). For small rotations dq, this is a fair enough approximation.
-    // But this is wrong enough for testing! The error is in the order of magnitude of the angle, i.e., 1% error for rotB_angle = 1e-2 rad.
-    // To pass the test, and actually exercise the code the way it is currently written (even though that way is wrong !!!) we are using additive rotation vector decomposition
-
-    // TODO JBC: The commented line below is the mathematically correct multiplicative decomposition
-    // ChVector3d rot_incr = drotB;
-    // TODO JBC: The line below is for the small rotation assumption used in the code.
-    // Once/if we debug and refactor this aspect of the code, this test should fail and we should use the commented line above instead
-    ChVector3d rot_incr = qB.GetRotVec() - qB_ini.GetRotVec();
+    ChVector3d rot_incr = drotB;
 
     ChVectorN<double, 12> Fi_analytical;
     ChVector3<> imposed_local_strain = facetFrame.transpose() * (dispB + rot_incr.Cross(center - posNodeB)) / length;

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -65,8 +65,9 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double facet_width = 3.165;
     double facet_height = 12.4864;
     double facet_area = facet_height * facet_width;
-    ChVectorN<double, 18> statev;
-    statev.setZero();
+    ChVectorN<double, 18> statev_old, statev_new;
+    statev_old.setZero();
+    statev_new.setZero();
     ChVector3d strain(4.186, 1.16, -86.48);
     ChVector3d curvature(0.123, -0.864, 0.793);
 
@@ -75,7 +76,7 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     ChVector3d couple;
     double random_field = 1.0; // NO RANDOM FIELD
     ChVector3d eigeinstrain(0.0); // NO EIGENSTRAIN
-    my_mat->ComputeStress(strain, curvature, eigeinstrain, length, statev, facet_area, facet_width, facet_height, random_field, stress, couple);
+    my_mat->ComputeStress(strain, curvature, eigeinstrain, length, statev_old, statev_new, facet_area, facet_width, facet_height, random_field, stress, couple);
 
 }
 


### PR DESCRIPTION
### Summary

This PR:

1.  modified the way CBL connectors compute and update strain.
2. implements a second state variable vector to be able to update at every step vs at very iteration (this change in update is not done yet)

### Changes made

#### DOFs / strain calculation and update

In the former implementation, the connector holds the old DOFs, and updates them every time `ComputeInternalForces` is called.
This design:
1. can cause issues if forces are probed but no change in nodal coordinates / strain is actually occuring in the simulation, e.g., when building matrix stiffness using finite differences (this is not exercised in CBLCON so this is not "our" problem but remain "a" problem)
3. is not necessary
   - At the element level, there is no need to store the DOFS history. The role of the element is to compute the strain from the nodal kinematics, and pass it to the CBL constitutive model.
   - the CBL constitutive model stores the history that it needs to perform the path-dependent calculations in the state variables, the element does not need this
4. is confusing and risky (for reasons similar to 1.)
   -  if one wrong update is done, the calculations takes an irreversible path that is wrong
   - side effect: it is easy to forget that the function that computes forces is also overwriting kinematics variables (that is not its role. Why are we even doing this inside this function?)


For all these reasons, it makes for simpler and clearer code to get rid of the `dofs_increment` and `dofs_old` in the `ChElementCBLON` object. This PR implement such changes, along with the necessary modifications to accommodate the new strain calculation structure:
1. using the DOFs, and not the increments requires the true rotation "displacement" to be calculated. The previous `GetStateBlock` implementation only returned the total rotation from the global frame
2. the input for the constitutive model is now the strain, not the increment, and the `ComputeStress` function is modified to account for that.
3. I had to modify the unit test for internal force calculations because the previous code computed the linearized increment in rotation (which is not valid in general), and I had coded the test to replicate that behavior. Now that we implement the true rotation, I changed to the valid code that I had in comments

PS1: This passes all unit tests, and the 0.5 mm elastic demo from Wisdom gives the same results as before.

#### State variables update

The change in strain described above was a necessary step towards changing the state variables update in `ChWoodMaterialVECT`, which is currently wrong for reasons similar to 1. and 3. and suspected to cause convergence issues.
Overwriting the state variables every time `ComputeInternalForces` can cause the material deformation history to change in an incorrect manner within a given step if the iterations taken by the solver (which we don't control) are not monotonic.

2 separate sets of state variables (old and new) are required to avoid that issue, and are implemented in this PR. The new state variables are computed and stored every time the constitutive model is called. However, they do not automatically overwrite the old values, which remain in memory until we chose to overwrite them when appropriate.

The current implementation does not change the old behavior, i.e., state variables are overwritten at every iteration.
**THE CURRENT BEHAVIOR SHOULD BE UNCHANGED (per the unit tests and my demos), PLEASE VERIFY WITH A SIMPLE DEMO THAT THIS IS THE CASE ON YOUR END**.
Overwriting the state variables at the end of the step internally in Chrono would require more intervention than I am willing to do now. I wrote a comment in the `ChElementCBLCON.cpp` file about how to use a quick hack to implement that in our demos without touching Chrono internals. I think we should stick to that until we have more testing done.

PS2: I apologize for the minor form refactor and unused code deletion that I also included in these commits and will make the review a little harder.

Thank you