### PR TITLE
General implementation of state variables in elements

### DIFF
--- a/src/chrono/fea/ChElementBase.h
+++ b/src/chrono/fea/ChElementBase.h
@@ -143,6 +143,13 @@ class ChApi ChElementBase {
     /// WILL BE DEPRECATED
     virtual void VariablesFbIncrementMq() {}
 
+    /// Get the number of state variables used by this element.
+    /// Number of quadrature (Gauss) points, multiplied by number of state variables of constitutive model
+    virtual unsigned int GetNumStateVar() {return 0;}
+
+    /// Update the state variables of the constitutive model at the end of the step
+    virtual void EleUpdateStateVar() {}
+
   private:
     /// Initial setup (called once before start of simulation).
     /// This is used mostly to precompute matrices that do not change during the simulation, i.e. the local stiffness of

--- a/src/chrono/fea/ChElementGeneric.cpp
+++ b/src/chrono/fea/ChElementGeneric.cpp
@@ -146,5 +146,10 @@ void ChElementGeneric::VariablesFbIncrementMq() {
     throw(std::runtime_error("ChElementGeneric::VariablesFbIncrementMq is deprecated"));
 }
 
+void ChElementGeneric::EleUpdateStateVar() {
+    if (GetNumStateVar() <= 0) return;
+    statevar_old = statevar;
+    }
+
 }  // end namespace fea
 }  // end namespace chrono

--- a/src/chrono/fea/ChElementGeneric.h
+++ b/src/chrono/fea/ChElementGeneric.h
@@ -91,8 +91,13 @@ class ChApi ChElementGeneric : public ChElementBase {
     /// Add M*q (internal masses multiplied current 'qb').
     virtual void VariablesFbIncrementMq() override;
 
+    /// Update the state variables of the constitutive model at the end of the step
+    virtual void EleUpdateStateVar() override;
+
   protected:
     ChKRMBlock Kmatr;
+    ChVectorDynamic<> statevar_old;
+    ChVectorDynamic<> statevar;
 };
 
 /// @} fea_elements

--- a/src/chrono/fea/ChMesh.cpp
+++ b/src/chrono/fea/ChMesh.cpp
@@ -169,6 +169,12 @@ void ChMesh::Update(double m_time, bool update_assets) {
     }
 }
 
+void ChMesh::EndOfStepInternalVariablesUpdate() {
+    for (unsigned int ie = 0; ie < velements.size(); ie++) {
+        velements[ie]->EleUpdateStateVar();
+    }
+}
+
 void ChMesh::AddCollisionModelsToSystem(ChCollisionSystem* coll_sys) const {
     for (const auto& surf : vcontactsurfaces)
         surf->AddCollisionModelsToSystem(coll_sys);

--- a/src/chrono/fea/ChMesh.h
+++ b/src/chrono/fea/ChMesh.h
@@ -148,6 +148,11 @@ class ChApi ChMesh : public ChIndexedNodes {
     /// Updates all [A] coord.systems for all (corotational) elements.
     virtual void Update(double m_time, bool update_assets) override;
 
+    /// Update internal material state variables that must only be modified at the end of step.
+    /// Contrary to Update() above, this function must only be called at the end of the step
+    /// because it will otherwise corrupt the loading path of the material model
+    virtual void EndOfStepInternalVariablesUpdate() override;
+
     /// Add the mesh contact surfaces (if any) to the provided collision system.
     virtual void AddCollisionModelsToSystem(ChCollisionSystem* coll_sys) const override;
 

--- a/src/chrono/physics/ChAssembly.cpp
+++ b/src/chrono/physics/ChAssembly.cpp
@@ -665,6 +665,27 @@ void ChAssembly::Update(double time, bool update_assets) {
     }
 }
 
+// Update assembly's data that must only be updated at the end of the step
+// Currently, this will only update the internal state variables of the mechanical constitutive equations
+// for FEA elements inside the ChMesh objects
+void ChAssembly::EndOfStepInternalVariablesUpdate() {
+    for (auto& body : bodylist) {
+        body->EndOfStepInternalVariablesUpdate();
+    }
+    for (auto& shaft : shaftlist) {
+        shaft->EndOfStepInternalVariablesUpdate();
+    }
+    for (auto& link : linklist) {
+        link->EndOfStepInternalVariablesUpdate();
+    }
+    for (auto& mesh : meshlist) {
+        mesh->EndOfStepInternalVariablesUpdate();
+    }
+    for (auto& item : otherphysicslist) {
+        item->EndOfStepInternalVariablesUpdate();
+    }
+}
+
 void ChAssembly::ForceToRest() {
     for (auto& body : bodylist) {
         body->ForceToRest();

--- a/src/chrono/physics/ChAssembly.h
+++ b/src/chrono/physics/ChAssembly.h
@@ -217,6 +217,9 @@ class ChApi ChAssembly : public ChPhysicsItem {
     /// Updates all the auxiliary data and children of bodies, forces, links, given their current state.
     virtual void Update(double time, bool update_assets) override;
 
+    /// Update internal variables that must only be modified at the end of step.
+    virtual void EndOfStepInternalVariablesUpdate() override;
+
     /// Set zero speed (and zero accelerations) in state, without changing the position.
     virtual void ForceToRest() override;
 

--- a/src/chrono/physics/ChPhysicsItem.h
+++ b/src/chrono/physics/ChPhysicsItem.h
@@ -96,6 +96,11 @@ class ChApi ChPhysicsItem : public ChObj {
     /// only if requested).
     virtual void Update(double time, bool update_assets) override;
 
+    /// Update internal variables that must only be modified at the end of step.
+    /// This is necessary for path-dependent data that can otherwise get corrupted
+    /// if updated at each iteration, e.g., internal variables of material constitutive model in FEA (plasticity)
+    virtual void EndOfStepInternalVariablesUpdate() {}
+
     /// Set zero speed (and zero accelerations) in state, without changing the position.
     /// Child classes should implement this function if GetNumCoordsPosLevel() > 0.
     /// It is used by owner ChSystem for some static analysis.

--- a/src/chrono/physics/ChSystem.cpp
+++ b/src/chrono/physics/ChSystem.cpp
@@ -1718,6 +1718,10 @@ AssemblyAnalysis::ExitFlag ChSystem::DoAssembly(int action,
     if (visual_system)
         visual_system->OnUpdate(this);
 
+    // TODO JBC: I believe the SV should be updated here, to be confirmed !
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    EndOfStepUpdates();
+
     return exit_flag;
 }
 
@@ -1790,6 +1794,11 @@ bool ChSystem::DoStaticAnalysis(ChStaticAnalysis& analysis) {
     if (visual_system)
         visual_system->OnUpdate(this);
 
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    //    For ChStaticNonLinearIncremental analyses, the end of step variables are updated after every load increment
+    //    inside `ChStaticNonLinearIncremental::StaticAnalysis()` and the call below is redundant with the update after the last load increment
+    EndOfStepUpdates();
+
     return true;
 }
 
@@ -1850,6 +1859,9 @@ bool ChSystem::DoStaticLinear() {
     if (visual_system)
         visual_system->OnUpdate(this);
 
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    EndOfStepUpdates();
+
     return true;
 }
 
@@ -1890,6 +1902,9 @@ bool ChSystem::DoStaticNonlinear(int nsteps, bool verbose) {
     // Update any attached visualization system
     if (visual_system)
         visual_system->OnUpdate(this);
+
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    EndOfStepUpdates();
 
     return true;
 }
@@ -1936,6 +1951,9 @@ bool ChSystem::DoStaticNonlinearRheonomic(
     if (visual_system)
         visual_system->OnUpdate(this);
 
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    EndOfStepUpdates();
+
     return true;
 }
 
@@ -1966,6 +1984,9 @@ bool ChSystem::DoStaticRelaxing(double step_size, int num_iterations) {
     // Update any attached visualization system
     if (visual_system)
         visual_system->OnUpdate(this);
+
+    // No need to call `EndOfStepUpdates()`.
+    // End of step data already updated by `DoFrameDynamics`
 
     return success;
 }

--- a/src/chrono/physics/ChSystem.cpp
+++ b/src/chrono/physics/ChSystem.cpp
@@ -1228,6 +1228,14 @@ void ChSystem::LoadConstraint_Ct(ChVectorDynamic<>& Qc, const double c) {
 }
 
 // -----------------------------------------------------------------------------
+//   END OF STEP UPDATE OPERATIONS
+// -----------------------------------------------------------------------------
+
+void ChSystem::EndOfStepUpdates() {
+    assembly.EndOfStepInternalVariablesUpdate();
+}
+
+// -----------------------------------------------------------------------------
 //   COLLISION OPERATIONS
 // -----------------------------------------------------------------------------
 
@@ -1616,6 +1624,9 @@ bool ChSystem::AdvanceDynamics() {
 
     // Executes custom processing at the end of step
     CustomEndOfStep();
+
+    // Updates path-dependent data in the assembly that must only be modified at the end of step
+    EndOfStepUpdates();
 
     // Call method to gather contact forces/torques in rigid bodies
     contact_container->ComputeContactForces();

--- a/src/chrono/physics/ChSystem.h
+++ b/src/chrono/physics/ChSystem.h
@@ -437,6 +437,13 @@ class ChApi ChSystem : public ChIntegrableIIorder {
     /// but if you inherit a special ChSystem you can implement this.
     virtual void CustomEndOfStep() {}
 
+    /// Executes typical processing at the end of step.
+    /// By default, this updates the internal material state variables for the FEA elements
+    /// TODO JBC: I did not modify the function above for backward compatibility in case any user has inherited a special ChSystem
+    ///           This should not be of concern for general Chrono development. Building on top is less intrusive.
+    //            CustomEndOfStep() could be deleted, or the present development could be set inside it, rather than creating a new EndOfStepUpdates() function
+    void EndOfStepUpdates();
+
     /// Perform the collision detection, returning the number of contacts.
     /// New contacts are inserted in the ChContactContainer object(s), and old ones are removed.
     /// This is mostly called automatically by time integration.

--- a/src/chrono/physics/ChSystem.h
+++ b/src/chrono/physics/ChSystem.h
@@ -442,7 +442,7 @@ class ChApi ChSystem : public ChIntegrableIIorder {
     /// TODO JBC: I did not modify the function above for backward compatibility in case any user has inherited a special ChSystem
     ///           This should not be of concern for general Chrono development. Building on top is less intrusive.
     //            CustomEndOfStep() could be deleted, or the present development could be set inside it, rather than creating a new EndOfStepUpdates() function
-    void EndOfStepUpdates();
+    void EndOfStepUpdates() override;
 
     /// Perform the collision detection, returning the number of contacts.
     /// New contacts are inserted in the ChContactContainer object(s), and old ones are removed.

--- a/src/chrono/timestepper/ChIntegrable.h
+++ b/src/chrono/timestepper/ChIntegrable.h
@@ -305,6 +305,11 @@ class ChApi ChIntegrableIIorder : public ChIntegrable {
                                  const ChStateDelta& Dx  ///< state increment Dx
     );
 
+    /// Executes typical processing at the end of step.
+    /// This updates the data in the assembly of the ChSystem. Defined here because it is needed by StaticAnalysis
+    virtual void EndOfStepUpdates() {
+        throw std::runtime_error("EndOfStepUpdates() not implemented, integrable must be of type ChSystem. ");
+    }
     //
     // Functions required by implicit integration schemes
     //

--- a/src/chrono/timestepper/ChStaticAnalysis.cpp
+++ b/src/chrono/timestepper/ChStaticAnalysis.cpp
@@ -205,7 +205,7 @@ void ChStaticNonLinearAnalysis::StaticAnalysis() {
             }
         }
 
-        X = Xnew;
+        X = Xnew; // TODO JBC: I think this is wrong. You should not update X until you converge (see HHT code)
 
         integrable->StateScatter(X, V, T, true);  // state -> system
         integrable->StateScatterReactions(L);     // -> system auxiliary data
@@ -769,9 +769,13 @@ void ChStaticNonLinearIncremental::StaticAnalysis() {
                 }
             }
 
-            X = Xnew;
+            X = Xnew; // TODO JBC: I think this is wrong. You should not update X until you converge (see HHT code)
 
         }  // end inner loop for Newton iteration
+
+        // Updates path-dependent data in the assembly that must only be modified at the end of step
+        // Each load increment is a step for which an update is necessary
+        integrable->EndOfStepUpdates();
 
     }  // end outer loop incrementing external loads
 

--- a/src/chrono_wood/ChBeamSectionCBLCON.cpp
+++ b/src/chrono_wood/ChBeamSectionCBLCON.cpp
@@ -34,15 +34,9 @@ ChBeamSectionCBLCON::ChBeamSectionCBLCON( std::shared_ptr<ChWoodMaterialVECT> ma
                                     ChVector3d center,    // Center point of the facet area      
                                     ChMatrix33<double> facetFrame    /// local system of frame of facet 
                                        )
-    : m_material{material}, m_area{area}, m_center{center}, m_facetFrame{facetFrame} {
-        m_state.setZero();
-        m_state_new.setZero();
-}
+    : m_material{material}, m_area{area}, m_center{center}, m_facetFrame{facetFrame} {}
 
-ChBeamSectionCBLCON::ChBeamSectionCBLCON() {
-	m_state.setZero();
-    m_state_new.setZero();
-};
+ChBeamSectionCBLCON::ChBeamSectionCBLCON() {};
 
 ChBeamSectionCBLCON::~ChBeamSectionCBLCON() {};
 

--- a/src/chrono_wood/ChBeamSectionCBLCON.h
+++ b/src/chrono_wood/ChBeamSectionCBLCON.h
@@ -50,8 +50,6 @@ namespace wood {
 class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection { 
   public:
 
-    using StateVarVector = ChVectorN<double, 18>;
-
     ChBeamSectionCBLCON(  std::shared_ptr<ChWoodMaterialVECT> material,  // material 
                                     double area,    // Projected total area of the facet
                                     ChVector3d center,    // Center point of the facet area      
@@ -88,10 +86,6 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
     //
     ChMatrix33<double> Get_facetFrame() const { return m_facetFrame; }
     void Set_facetFrame( ChMatrix33<double> facetFrame) { m_facetFrame=facetFrame; }
-  
-    StateVarVector  Get_StateVar() const { return m_state; };
-    void Set_StateVar(StateVarVector  state) { m_state=state; }
-    void Set_StateVarNew(StateVarVector  state) { m_state_new=state; }
     
     enum ConSectionType { transverse_regular_bot, transverse_regular_gen, transverse_regular_top, longitudinal, tangential_ray_bot, tangential_ray_gen, tangential_ray_top, radial_ray_bot, radial_ray_gen, radial_ray_top};
     
@@ -117,18 +111,13 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
 	
 	ChVector3d Get_nonMechanicStrain() const { return m_nonMechanicStrain; };
     void Set_nonMechanicStrain(ChVector3d nonMechanicStrain) { m_nonMechanicStrain=nonMechanicStrain; }
-
-    void UpdateStateVariables() { m_state = m_state_new; }
     
     
   protected:
     std::shared_ptr<ChWoodMaterialVECT> m_material;
     ChVector3d m_center;
     ChMatrix33<double> m_facetFrame;
-    StateVarVector m_state;
-    StateVarVector m_state_new;
 	ChVector3d  m_nonMechanicStrain;
-    //std::shared_ptr<ChInternalDataCSL> m_state;  
     double mcon_width=1.0;  
     double mcon_height=1.0; 
     double m_area=1.0; 

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -484,8 +484,8 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
     //
     // Initiliaze state variables:
     //
-    // All state variables initialized at zero, which is the value in the Section constructor
-    // Nothing to do here
+    statevar_old.setZero(GetNumStateVar());
+    statevar.setZero(GetNumStateVar());
 
     //
     if(this->macro_strain){
@@ -612,30 +612,8 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     double height=mysection->GetHeight()/2;
     double random_field =mysection->GetRandomField();
     auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
-    StateVarVector statev_old = mysection->Get_StateVar();
-    StateVarVector statev_new;
-    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statev_old, statev_new, area, width, height, random_field, mstress, mcouple);
+    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statevar_old, statevar, area, width, height, random_field, mstress, mcouple);
 
-    mysection->Set_StateVarNew(statev_new);
-
-    // Code below replicates current behavior: updates state variables at every call to ComputeInternalForces, which is incorrect!
-    // TODO: to update at every step, we will need to call the function below (or equivalent, at the end of every step).
-    //       The Element has no idea how the timestepper operates, so we would have to do this outside of this Class.
-    //       and requires modifications to the base parent classes for the elements, and Chrono timestepper behavior.
-    //
-    //       A quick and dirty way to do this for now is to manually update the state variables inside the "run step" loop in the `main()` function of our compiled demos, e.g.:
-    // 
-    //          while (sys.GetChTime() < duration) {
-    //              sys.DoStepDynamics(timestep);
-    //              for (auto& element : my_mesh->GetElements()) {
-    //                  if (auto connector = std::dynamic_pointer_cast<ChElementCBLCON>(element)) {
-    //                      connector->GetSection()->UpdateStateVariables();
-    //                  }
-    //              }
-    //          }
-    // 
-    // Comment line below and add code above to your CBL demo to implement update at end of step only
-    mysection->Set_StateVar(statev_new);
 
     ChVector3d force = area * (nmL_tr * mstress);
     ChVector3d xc_xi;
@@ -833,8 +811,7 @@ double ChElementCBLCON::GetDensity() {
 ChMatrixNM<double, 1, 9> ChElementCBLCON::ComputeMacroStressContribution(){
     ChMatrixNM<double, 1, 9> macro_stress;
     double area =this->section->Get_area();
-    auto statev= this->section->Get_StateVar();
-    macro_stress =(this->section->GetProjectionMatrix()).transpose()*statev.segment(3,3)*area*this->length;
+    macro_stress =(this->section->GetProjectionMatrix()).transpose()*statevar.segment(3,3)*area*this->length;
 
     return macro_stress;
 }

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -47,7 +47,6 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
   public:
     using ShapeVector = ChMatrixNM<double, 1, 10>;
     using Amatrix = ChMatrixNM<double,3,6> ;
-    using StateVarVector = ChVectorN<double, 18>;
 
     ChElementCBLCON();
 
@@ -56,6 +55,7 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
     virtual unsigned int GetNumNodes() override { return 2; }
     virtual unsigned int GetNumCoordsPosLevel() override { return 2 * 6; }
     virtual unsigned int GetNodeNumCoordsPosLevel(unsigned int n) override { return 6; }
+    virtual unsigned int GetNumStateVar() override { return 1 * section->Get_material()->GetNumberOfStateVariables(); }
 
     virtual std::shared_ptr<ChNodeFEAbase> GetNode(unsigned int n) override { return nodes[n]; }
 	

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,7 +49,7 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, StateVarVector& statev_old, StateVarVector& statev_new,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, const ChVectorDynamic<>& statev_old, ChVectorDynamic<>& statev_new,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
     	ChVector3d mstrain;
     	ChVector3d mcurvature;
 
@@ -355,7 +355,7 @@ void ChWoodMaterialVECT::ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& 
 
 
 
-double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev, double eps_max) {
+double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, const ChVectorDynamic<>& statev_old, double eps_max) {
 	//
 	double E0 = this->Get_E0();
 	double alpha = this->Get_alpha();
@@ -397,13 +397,13 @@ double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field,
 
 	double sigma_bt = sigma0 * exp(-H0 * std::max((eps_max - eps0), 0.0) / sigma0);
 
-	double strs_ela = E0 * (epsQ - statev(8)) + statev(9); // The elastic prediction increments from old values. TODO: take this out of this function, not its role
+	double strs_ela = E0 * (epsQ - statev_old(8)) + statev_old(9); // The elastic prediction increments from old values. TODO: take this out of this function, not its role
 	double sigma_fr = std::min(std::max(strs_ela, 0.0), sigma_bt);
 	return sigma_fr;
 }
 
 
-double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, StateVarVector& statev) {
+double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, const ChVectorDynamic<>& statev_old) {
 	//
 	double E0 = this->Get_E0();
 	double alpha = this->Get_alpha();
@@ -445,7 +445,7 @@ double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field,
 	
 	
 
-	double strs_ela = E0 * (epsQ - statev(8)) + statev(9);  // The elastic prediction increments from old values. TODO: take this out of this function, not its role
+	double strs_ela = E0 * (epsQ - statev_old(8)) + statev_old(9);  // The elastic prediction increments from old values. TODO: take this out of this function, not its role
 	double sigma_fr = std::min(std::max(strs_ela, 0.0), sigma_bt);
 	//std::cout<<"epsQ: "<<epsQ<<" epsQ_0: "<<statev(8)<<" sigma_0: "<<statev(9)<<" strs_ela: "<<strs_ela<<"\tsigma_bt: "<<sigma_bt<<"\tsigma_fr: "<<sigma_fr<<std::endl;
 	//exit(9);

--- a/src/chrono_wood/ChWoodMaterialVECT.h
+++ b/src/chrono_wood/ChWoodMaterialVECT.h
@@ -19,6 +19,7 @@
 #ifndef CHWOODMATERIALVECT_H
 #define CHWOODMATERIALVECT_H
 
+#include "chrono/core/ChMatrix.h"
 #include "chrono/core/ChVector3.h"
 #include "chrono_wood/ChWoodApi.h"
 #include "chrono/core/ChMatrix33.h"
@@ -35,7 +36,6 @@ namespace wood {
 /// Definition of materials to be used for CSL beams and LDPM tets utilizing the lattice discrete particle model.
 class ChWoodApi ChWoodMaterialVECT {
   public:
-    using StateVarVector = ChVectorN<double, 18>;
 
     /// Construct an isotropic elastic material.
     ChWoodMaterialVECT(double rho,  		///< material density
@@ -99,19 +99,22 @@ class ChWoodApi ChWoodMaterialVECT {
 	/// Return the tensile unloading.
     double GetElasticAnalysisFlag() const { return m_ElasticAnalysis; }
     void SetElasticAnalysisFlag(double ElasticAnalysis) { m_ElasticAnalysis = ElasticAnalysis; }	
+
+    /// Return the number of state variable required by this constitutive model
+    int GetNumberOfStateVariables() { return m_num_state_var; }
 	
 	
 	/// Return the tensile unloading.
     double GetCoupleContrib2EquStrainFlag() const { return m_CoupleContrib2EquStrain; }
     void SetCoupleContrib2EquStrainFlag(double CoupleContrib2EquStrain) { m_CoupleContrib2EquStrain = CoupleContrib2EquStrain; }	
     /// Compute stresses from given strains and state variables.
-    void ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, StateVarVector& statev_old, StateVarVector& statev_new, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
+    void ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigeinstrain, double &len, const ChVectorDynamic<>& statev_old, ChVectorDynamic<>& statev_new, double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple);
     //void ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& curvature_incr, double &length, StateVarVector& statev, double& width, double& height, double& random_field, ChVector3d& stress, ChVector3d& surfacic_couple);
     //
     
-    double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, StateVarVector& statev, double eps_max);
+    double FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, const ChVectorDynamic<>& statev_old, double eps_max);
 
-	double CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, StateVarVector& statev);
+	double CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, const ChVectorDynamic<>& statev_old);
     
   private:
     
@@ -129,6 +132,7 @@ class ChWoodApi ChWoodMaterialVECT {
     double mcouple_mult=0; ///<  influence factor for rotational DOF: beta_N = beta_M = beta_B
 	bool m_ElasticAnalysis=false;
 	bool m_CoupleContrib2EquStrain=false;
+    const int m_num_state_var = 18;
   //public:
   //EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_MaterialVECT.cpp
@@ -65,9 +65,8 @@ TEST(WoodMaterialVECTTest, stress_no_eigenstrain){
     double facet_width = 3.165;
     double facet_height = 12.4864;
     double facet_area = facet_height * facet_width;
-    ChVectorN<double, 18> statev_old, statev_new;
-    statev_old.setZero();
-    statev_new.setZero();
+    ChVectorDynamic<> statev_old(my_mat->GetNumberOfStateVariables());
+    ChVectorDynamic<> statev_new(my_mat->GetNumberOfStateVariables());
     ChVector3d strain(4.186, 1.16, -86.48);
     ChVector3d curvature(0.123, -0.864, 0.793);
 


### PR DESCRIPTION
This PR
* creates state variables at the element level in `ChElementGeneric`
* updates these state variables only once at the end of a step in all of the available analyses in `ChSystem`
   * incremental static analysis `ChStaticNonLinearIncremental` performs multiple load increments and state variables are updated at each of these sub-steps

TODO:

* I don't fully understand Kinematics analyses e.g., `DoStepKinematics` so not sure the automatic update of state variables is done correctly there.

