### PR TITLE
Finalize CBLCON updated lagrange with stored DOFs as state variable + large deflection for connectors

### DIFF
--- a/src/chrono_wood/ChBeamSectionCBLCON.cpp
+++ b/src/chrono_wood/ChBeamSectionCBLCON.cpp
@@ -34,7 +34,7 @@ ChBeamSectionCBLCON::ChBeamSectionCBLCON( std::shared_ptr<ChWoodMaterialVECT> ma
                                     ChVector3d center,    // Center point of the facet area      
                                     ChMatrix33<double> facetFrame    /// local system of frame of facet 
                                        )
-    : m_material{material}, m_area{area}, m_center{center}, m_facetFrame{facetFrame} {}
+    : m_material{material}, m_area{area}, m_center_ref{center}, m_center{center}, m_facetFrame{facetFrame} {}
 
 ChBeamSectionCBLCON::ChBeamSectionCBLCON() {};
 

--- a/src/chrono_wood/ChBeamSectionCBLCON.h
+++ b/src/chrono_wood/ChBeamSectionCBLCON.h
@@ -83,6 +83,9 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
     // Setter & Getter for centroid of facet
     ChVector3d Get_center() const { return m_center; }
     void Set_center( ChVector3d center) { m_center=center; }
+    // Setter & Getter for initial (reference configuration) centroid of facet
+    ChVector3d Get_center_ref() const { return m_center_ref; }
+    void Set_center_ref( ChVector3d center) { m_center_ref=center; }
     //
     ChMatrix33<double> Get_facetFrame() const { return m_facetFrame; }
     void Set_facetFrame( ChMatrix33<double> facetFrame) { m_facetFrame=facetFrame; }
@@ -116,6 +119,7 @@ class ChWoodApi ChBeamSectionCBLCON  : public ChBeamSection {
   protected:
     std::shared_ptr<ChWoodMaterialVECT> m_material;
     ChVector3d m_center;
+    ChVector3d m_center_ref;
     ChMatrix33<double> m_facetFrame;
 	ChVector3d  m_nonMechanicStrain;
     double mcon_width=1.0;  

--- a/src/chrono_wood/ChBuilderCBLCON.cpp
+++ b/src/chrono_wood/ChBuilderCBLCON.cpp
@@ -365,7 +365,7 @@ void ChBuilderCBLCON::read_CBLCON_info(std::shared_ptr<ChMesh> my_mesh,  std::sh
 		msection->SetWidth(connector.width);
 		msection->SetHeight(connector.height);
 		msection->Set_area(area);
-		msection->Set_center(facetC);
+		msection->Set_center_ref(facetC);
 		if (connector.conType==4 & mvec.Length()!=0){
 			msection->Set_facetFrame(nmL);
 		}else{
@@ -572,7 +572,7 @@ void ChBuilderCBLCON::read_CBLCON_info(std::shared_ptr<ChMesh> my_mesh,  std::ve
 		msection->SetWidth(connector.width);
 		msection->SetHeight(connector.height);
 		msection->Set_area(area);
-		msection->Set_center(facetC);
+		msection->Set_center_ref(facetC);
 		msection->SetRandomField(connector.randomField);
 		if (connector.conType==4 & mvec.Length()!=0){
 			//std::cout<<"Longuitidonal connector\n";

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -122,12 +122,6 @@ void ChElementCBLCON::Update() {
     } else { // JBC: This might not be necessary since the value of 0.0 in SetupInitial() should remain if macro_strain is nullptr
         this->section->Set_nonMechanicStrain(ChVector3d(0.0, 0.0, 0.0));
     }
-    // get displacement increment between current step and previous step
-    // update total displacement increment
-    //ChVectorDynamic<> displ(12);
-    //this->GetStateBlock(displ);
-    //dofs_increment=displ-dofs_old;
-    //dofs_old=displ;
 }
 
 void ChElementCBLCON::UpdateRotation() {
@@ -146,17 +140,44 @@ void ChElementCBLCON::UpdateRotation() {
     q_element_abs_rot = Aabs.GetQuaternion();
     */
 
-    // TODO JBC: I think the code below does not work for large displacement.
-    // the Y axis of the nodes are not necessarily aligned (even on average) with the y axis of the beam
-    // This approach may rotate the L and M directions of the facet by the wrong amount,
-    // causing the strain increment not to be added in the correct direction
-    // I believe the commented code above for beams should be used instead
+    // TODO JBC: This looks fragile and relies on assumptions and current behavior of other parts of the code
+    //           - If the Y-axes are aligned with the node-to-node direction, or cancel out, Gram-Schmidt will fail and use an arbitrary direction
+    //              This arbitrary direction is repeatable, that is the only thing that guarantee this works, otherwise, the initial quaternion determined in SetupInitial() might be different
+    //              Any change to the fallback behavior of ChMatrix33::SetFromAxisX() will break this code !
+    //           - I believe the commented code above for beams should be used instead, together with the initial quaternion being aligned with nmL matrix, similar to the beam element
     ChVector3d mXele = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
     ChVector3d mYele =
     (nodes[0]->Frame().GetRotMat().GetAxisY() + nodes[1]->Frame().GetRotMat().GetAxisY()).GetNormalized();
     Aabs.SetFromAxisX(mXele, mYele);
     q_element_abs_rot = Aabs.GetQuaternion();
     this->A.SetFromQuaternion(q_element_ref_rot.GetConjugate() * q_element_abs_rot);
+
+    // New center position
+    // 1. Projection `P` of center `C` on the edge should remain in the same relative position along the edge
+    ChVector3d edge0 = nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos();
+    double length0sq = edge0.Length2();
+    ChVector3d xi_xc0 = section->Get_center_ref() - nodes[0]->GetX0().GetPos();
+    double relpos_xi_xp = xi_xc0.Dot(edge0) / length0sq;
+    // 2. Vector `PC` keeps the same length but rotates with the edge
+    ChQuaternion<> q_delta = q_element_abs_rot * q_element_ref_rot.GetConjugate();
+    ChVector3d xi_xp0 = relpos_xi_xp * edge0;
+    ChVector3d xp_xc0 = xi_xc0 - xi_xp0;
+    ChVector3d edge = nodes[1]->GetPos() - nodes[0]->GetPos();
+    ChVector3d center = nodes[0]->GetPos() + relpos_xi_xp * edge + q_delta.Rotate(xp_xc0);
+    section->Set_center(center);
+}
+
+
+void ChElementCBLCON::ComputeBranchVectors(ChVector3d& xi_xc, ChVector3d& xj_xc) {
+    if (!ChElementCBLCON::LargeDeflection) {
+        // For small deflection, use the initial position of the nodes and facet centers
+        xi_xc = section->Get_center_ref() - nodes[0]->GetX0().GetPos();
+        xj_xc = section->Get_center_ref() - nodes[1]->GetX0().GetPos();
+    } else {
+        // For large deflection, use the current position of the nodes and facet centers
+        xi_xc = section->Get_center() - nodes[0]->GetPos();
+        xj_xc = section->Get_center() - nodes[1]->GetPos();
+    }
 }
 
 
@@ -195,19 +216,8 @@ void ChElementCBLCON::ComputeStrainIncrement(ChVectorN<double, 12>& dofs_increme
     ChVector3d dri = dofs_increment.segment(3,3);
     ChVector3d duj = dofs_increment.segment(6,3);
     ChVector3d drj = dofs_increment.segment(9,3);
-    ChVector3d xc_xi;
-    ChVector3d xc_xj;
+
     double linv = 1.0 / this->length;
-    // For small deflection, use the initial position of the nodes and facet centers
-    // to determine the displacement induced by the node rotation
-    if (!LargeDeflection) {
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos();
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos();
-    }
-    else { // TODO: Find out how to evolve position of the center for large displacement
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos(); // TEMPORARY
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos(); // TEMPORARY
-    }
 
     ChMatrix33<double> nmL=this->section->Get_facetFrame();
     if(ChElementCBLCON::LargeDeflection){	// TODO JBC: If the facet orientation is made to coincide with the quaternion, we could save a lot and move this to Update()
@@ -217,8 +227,11 @@ void ChElementCBLCON::ComputeStrainIncrement(ChVectorN<double, 12>& dofs_increme
         }
     }
 
+    ChVector3d xi_xc, xj_xc;
+    ComputeBranchVectors(xi_xc, xj_xc);
+
     // Strain
-    strain_increment = nmL * (duj + drj.Cross(xc_xj) - (dui + dri.Cross(xc_xi))) * linv;
+    strain_increment = nmL * (duj + drj.Cross(xj_xc) - (dui + dri.Cross(xi_xc))) * linv;
 
     // Curvature
     if (ChElementCBLCON::EnableCoupleForces){
@@ -240,14 +253,12 @@ void ChElementCBLCON::ComputeMmatrixGlobal(ChMatrixRef M) {
     if (!ChElementCBLCON::LargeDeflection) {
         pNA = this->GetNodeA()->GetX0().GetPos();
         pNB = this->GetNodeB()->GetX0().GetPos();
-        pC = this->section->Get_center();
+        pC = this->section->Get_center_ref();
     } else {
-        // TODO JBC: Technically, if the connector is stretched, at constant mass, the moment of inertia changes
-        // Decide whether or not we want to take this into account in the calculation of the length or ignored it. error ~ 2*max_strain
-        // Currently use the same length for simplicity
-        pNA = this->GetNodeA()->GetX0().GetPos(); // TEMPORARY
-        pNB = this->GetNodeB()->GetX0().GetPos(); // TEMPORARY
-        pC = this->section->Get_center(); // TEMPORARY
+        // JBC: Technically, if the connector is stretched, at constant mass, the moment of inertia changes
+        pNA = this->GetNodeA()->GetPos();
+        pNB = this->GetNodeB()->GetPos();
+        pC = this->section->Get_center();
     }
     double LA=(pC-pNA).Length();
     double LB=(pC-pNB).Length(); // TODO JBC: This could be length - LA, but will likely change when we refactor the center from a Vector into a scalar along the line
@@ -346,26 +357,19 @@ void ChElementCBLCON::ComputeStiffnessMatrixGlobal(ChMatrixRef Km) {
         ChMatrix33<double> nmL_tr = nmL.transpose();
         ChMatrix33<> K_local = nmL_tr * K_diag * nmL;
 
-        // For small deflection, use the initial position of the nodes and facet centers
-        // to determine the displacement induced by the node rotation
-        ChVector3d xc_xi;
-        ChVector3d xc_xj;
-        if (!LargeDeflection) {
-            xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos();
-            xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos();
-        }
-        else { // TODO: Find out how to evolve position of the center for large displacement
-            xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos(); // TEMPORARY
-            xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos(); // TEMPORARY
-        }
-        ChMatrix33<> Ai_cross; // 3x3 right sub-block of Ai matrix for skew-symmetric cross-product vector
-        ChMatrix33<> Aj_cross; // 3x3 right sub-block of Aj matrix for skew-symmetric cross-product vector
-        Ai_cross << 0.0      ,  xc_xi[2], -xc_xi[1],
-                    -xc_xi[2],  0.0     ,  xc_xi[0],
-                     xc_xi[1], -xc_xi[0],  0.0     ;
-        Aj_cross << 0.0      ,  xc_xj[2], -xc_xj[1],
-                    -xc_xj[2],  0.0     ,  xc_xj[0],
-                     xc_xj[1], -xc_xj[0],  0.0     ;
+
+        ChVector3d xi_xc, xj_xc;
+        ComputeBranchVectors(xi_xc, xj_xc);
+        // 3x3 right sub-block of Ai matrix for skew-symmetric cross-product vector
+        ChMatrix33<> Ai_cross(0.0);
+        Ai_cross(0,1) =  xi_xc[2]; Ai_cross(1,0) = -xi_xc[2];
+        Ai_cross(0,2) = -xi_xc[1]; Ai_cross(2,0) =  xi_xc[1];
+        Ai_cross(1,2) =  xi_xc[0]; Ai_cross(2,1) = -xi_xc[0];
+        // 3x3 right sub-block of Aj matrix for skew-symmetric cross-product vector
+        ChMatrix33<> Aj_cross(0.0);
+        Aj_cross(0,1) =  xj_xc[2]; Aj_cross(1,0) = -xj_xc[2];
+        Aj_cross(0,2) = -xj_xc[1]; Aj_cross(2,0) =  xj_xc[1];
+        Aj_cross(1,2) =  xj_xc[0]; Aj_cross(2,1) = -xj_xc[0];
 
         ChMatrix33<> K_local_Id_Ai = K_local * Ai_cross;
         ChMatrix33<> K_local_Ai_Id = K_local_Id_Ai.transpose();
@@ -443,10 +447,9 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
         (nodes[0]->GetX0().GetRotMat().GetAxisY() + nodes[1]->GetX0().GetRotMat().GetAxisY()).GetNormalized();
     A0.SetFromAxisX(mXele, myele);
     q_element_ref_rot = A0.GetQuaternion();
-    //
-    // WARNNING: Check updating rotation here is a good idea
-    //
-    this->UpdateRotation();
+    q_element_abs_rot = q_element_ref_rot; // Initialize the current quaternion as the reference quaternion
+
+    section->Set_center(section->Get_center_ref());
     //
     // Initiliaze state variables:
     //
@@ -592,25 +595,15 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     ChVector3d mstress, mcouple;
     section->Get_material()->ComputeStress(strain_increment, curvature_increment, nonMechanicalStrain, length, statevar_old, statevar, area, width, height, random_field, mstress, mcouple);
 
-
     ChVector3d force = area * (nmL_tr * mstress);
-    ChVector3d xc_xi;
-    ChVector3d xc_xj;
-    // For small deflection, use the initial position of the nodes and facet centers
-    // to determine the displacement induced by the node rotation
-    if (!LargeDeflection) {
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos();
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos();
-    }
-    else { // TODO: Find out how to evolve position of the center for large displacement
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos(); // TEMPORARY
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos(); // TEMPORARY
-    }
+
+    ChVector3d xi_xc, xj_xc;
+    ComputeBranchVectors(xi_xc, xj_xc);
 
     Fi.segment(0,3) =  force.eigen();
-    Fi.segment(3,3) =  xc_xi.Cross(force).eigen();
+    Fi.segment(3,3) =  xi_xc.Cross(force).eigen();
     Fi.segment(6,3) = -force.eigen();
-    Fi.segment(9,3) = -xc_xj.Cross(force).eigen();
+    Fi.segment(9,3) = -xj_xc.Cross(force).eigen();
 
     if(ChElementCBLCON::EnableCoupleForces){
         ChVector3d couple_global = area * (nmL_tr * mcouple);
@@ -653,34 +646,25 @@ void ChElementCBLCON::EvaluateSectionDisplacement(const double eta, ChVector3d& 
     ChVector3d uj = nodes[1]->GetPos() - nodes[1]->GetX0().GetPos();
     (nodes[1]->GetRot() * nodes[1]->GetX0().GetRot().GetConjugate()).GetAngleAxis(angle, axis);
     ChVector3d rj = axis*angle;
-    ChVector3d xc_xi;
-    ChVector3d xc_xj;
-    // For small deflection, use the initial position of the nodes and facet centers
-    // to determine the displacement induced by the node rotation
-    if (!LargeDeflection) {
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos();
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos();
-    }
-    else { // TODO: Find out how to evolve position of the center for large displacement
-        xc_xi = this->section->Get_center() - this->nodes[0]->GetX0().GetPos(); // TEMPORARY
-        xc_xj = this->section->Get_center() - this->nodes[1]->GetX0().GetPos(); // TEMPORARY
-    }
+
+    ChVector3d xi_xc, xj_xc;
+    ComputeBranchVectors(xi_xc, xj_xc);
 
     // TODO JBC: This assumes small displacements
     // If the connector is broken and stretched, length will be very large eta_center poorly estimated
     // If we want to display the broken connector, I think a much bigger refactor would be needed because it does not really make sense
     // to call this function over normalized eta, and for many points uniformly distributed along the beam at a given resolution.
     // We should instead call over the actual distance, and evaluate only at the ends and facet discontinuities. Dispaly it as 2 elements, not one.
-    double eta_center = -1.0 + 2.0 * xc_xi.Length() / this->length;
+    double eta_center = -1.0 + 2.0 * xi_xc.Length() / this->length;
 
     // TODO JBC: I think using the rotation matrix rather, than the cross product, would give the true displacement for large displacement without other changes necessary
     if (eta <= eta_center) {
         double factor = (eta + 1.0) / (eta_center + 1.0);
-        u_displ = ui + ri.Cross(xc_xi) * factor;
+        u_displ = ui + ri.Cross(xi_xc) * factor;
         u_rotaz = ri;
     } else {
         double factor = (1.0 - eta) / (1.0 - eta_center);
-        u_displ = uj + rj.Cross(xc_xj) * factor;
+        u_displ = uj + rj.Cross(xj_xc) * factor;
         u_rotaz = rj;
     }
 }

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -160,48 +160,15 @@ void ChElementCBLCON::UpdateRotation() {
 }
 
 
-
-
-
-void ChElementCBLCON::GetStateBlock(ChVectorDynamic<>& mD) {
-    mD.resize(12);
-
-    // Node displacement
-    // If large deflection disabled, return displacement in global frame
-    // TODO: Go back to this function when we decide how to enable and formulate large deflection
-    auto getDisplacement = [&](std::shared_ptr<ChNodeFEAxyzrot> node) {
-        ChVector3d global_disp;
-        if (!LargeDeflection)
-            global_disp = node->Frame().GetPos() - node->GetX0().GetPos();
-        else
-            global_disp = node->Frame().GetPos() - node->GetX0().GetPos(); // TODO: temporary
-        return global_disp;
-    };
-
-    // Node rotations
-    // If Large deflection disabled, return rotation in global frame
-    // TODO: Go back to this function when we decide how to enable and formulate large deflection
-    auto getRotation = [&](std::shared_ptr<ChNodeFEAxyzrot> node) {
-        ChQuaternion<> global_dq = node->Frame().GetRot() * node->GetX0().GetRot().GetConjugate();
-        ChVector3d delta_rot_dir;
-        double delta_rot_angle;
-
-        if (!LargeDeflection)
-            global_dq.GetAngleAxis(delta_rot_angle, delta_rot_dir);
-        else
-            global_dq.GetAngleAxis(delta_rot_angle, delta_rot_dir); // TODO: temporary
-        // TODO: GetAngleAxis already returns in the range [-PI..PI], no need to change range
-        // TODO: the previous range was only shifted if delta_rot_angle > CH_PI. How about delta_rot_angle < - CH_PI ? Was that a bug?
-        // TODO: We may want to use GetRotVec directly, but the angle is not within [-PI .. PI]
-        // TODO: Consider changing GetRotVec() to return within [-PI .. PI]
-        return delta_rot_angle * delta_rot_dir;
-    };
-
-    mD.segment(0, 3) = getDisplacement(nodes[0]).eigen();
-    mD.segment(3, 3) = getRotation(nodes[0]).eigen();
-
-    mD.segment(6, 3) = getDisplacement(nodes[1]).eigen();
-    mD.segment(9, 3) = getRotation(nodes[1]).eigen();
+void ChElementCBLCON::GetStateBlock(ChVectorDynamic<>& statev) {
+    // Copy paste of ChElementLDPM::LoadableGetStateBlockPosLevel because this function
+    // takes ChVectorDynamic as an argument, not a ChState
+    unsigned index_start = GetDOFOffset();
+    statev.segment(index_start + 0, 3) = nodes[0]->GetPos().eigen();
+    statev.segment(index_start + 3, 4) = nodes[0]->GetRot().eigen();
+    //
+    statev.segment(index_start + 7, 3) = nodes[1]->GetPos().eigen();
+    statev.segment(index_start + 10, 4) = nodes[1]->GetRot().eigen();
 }
 
 
@@ -222,12 +189,12 @@ void ChElementCBLCON::GetField_dt(ChVectorDynamic<>& mD_dt) {
 }
 
 
-void ChElementCBLCON::ComputeStrain(ChVectorN<double, 12>& displ, ChVector3d& mstrain, ChVector3d& curvature) {
+void ChElementCBLCON::ComputeStrainIncrement(ChVectorN<double, 12>& dofs_increment, ChVector3d& strain_increment, ChVector3d& curvature_increment) {
     //
-    ChVector3d ui = displ.segment(0,3);
-    ChVector3d ri = displ.segment(3,3);
-    ChVector3d uj = displ.segment(6,3);
-    ChVector3d rj = displ.segment(9,3);
+    ChVector3d dui = dofs_increment.segment(0,3);
+    ChVector3d dri = dofs_increment.segment(3,3);
+    ChVector3d duj = dofs_increment.segment(6,3);
+    ChVector3d drj = dofs_increment.segment(9,3);
     ChVector3d xc_xi;
     ChVector3d xc_xj;
     double linv = 1.0 / this->length;
@@ -251,12 +218,11 @@ void ChElementCBLCON::ComputeStrain(ChVectorN<double, 12>& displ, ChVector3d& ms
     }
 
     // Strain
-    ChVector3d strain_increment = (uj + rj.Cross(xc_xj) - (ui + ri.Cross(xc_xi))) * linv;
-    mstrain = nmL * strain_increment;
+    strain_increment = nmL * (duj + drj.Cross(xc_xj) - (dui + dri.Cross(xc_xi))) * linv;
 
     // Curvature
     if (ChElementCBLCON::EnableCoupleForces){
-        curvature = nmL * (rj - ri) * linv;
+        curvature_increment = nmL * (drj - dri) * linv;
     }
 }
 
@@ -485,8 +451,8 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
     // Initiliaze state variables:
     //
     statevar_old.setZero(GetNumStateVar());
-    statevar.setZero(GetNumStateVar());
-
+    GetStateBlock(statevar_old); // Store DOFs at the end of state variables vector (temporary, to do updated Lagrangian until these are stored at the nodes in Tasora's new design)
+    statevar = statevar_old;
     //
     if(this->macro_strain){
             this->section->ComputeProjectionMatrix();
@@ -583,10 +549,25 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     assert(Fi.size() == 12);
     assert(section);
 
-    // Displacement and rotation of nodes:
-    ChVectorDynamic<> displ(12);
-    this->GetStateBlock(displ); // TODO: bad Chrono design, there is no reason for that function to exist in higher-level parent with dynamic vector since it is never used outside of element. Each element should decide how to handle their DOFS
-    ChVectorN<double, 12> dofs = displ;
+    // Compute increment of DOFs in global frame
+    this->GetStateBlock(statevar); // Store current DOFs at the end of state variables vector (temporary, to do updated Lagrangian until these are stored at the nodes in Tasora's new design)
+    ChVectorN<double, 12> dofs_increment;
+    for (int inode = 0 ; inode < 2 ; inode++) {
+        unsigned int index_start = GetDOFOffset();
+        // Displacement in global frame
+        dofs_increment.segment(inode*6,3) = statevar.segment(index_start + inode*7,3) - statevar_old.segment(index_start + inode*7,3);
+
+        // Rotation in global frame
+        ChQuaterniond q_curr(statevar.segment(index_start + inode*7 + 3,4));
+        ChQuaterniond q_prev(statevar_old.segment(index_start + inode*7 + 3,4));
+        ChQuaterniond dq = q_curr * q_prev.GetConjugate();
+        ChVector3d delta_rot_dir;
+        double delta_rot_angle;
+        dq.GetAngleAxis(delta_rot_angle, delta_rot_dir);
+        // TODO: We may want to use GetRotVec directly, but the angle is not within [-PI .. PI]
+        // TODO: Consider changing GetRotVec() to return within [-PI .. PI]
+        dofs_increment.segment(inode*6+3, 3) = (delta_rot_angle * delta_rot_dir).eigen();
+    }
 
     //
     // Get facet area and length of beam
@@ -601,18 +582,15 @@ void ChElementCBLCON::ComputeInternalForces(ChVectorDynamic<>& Fi) {
     }
     ChMatrix33<double> nmL_tr = nmL.transpose();
 
-    auto mysection=this->section;
-    ChVector3d mstress;
-    ChVector3d mstrain;
-    ChVector3d mcouple;
-    ChVector3d curvature;
+    ChVector3d strain_increment, curvature_increment;
+    ComputeStrainIncrement(dofs_increment, strain_increment, curvature_increment);
 
-    this->ComputeStrain(dofs, mstrain, curvature);
-    double width=mysection->GetWidth()/2;
-    double height=mysection->GetHeight()/2;
-    double random_field =mysection->GetRandomField();
-    auto nonMechanicalStrain=mysection->Get_nonMechanicStrain();
-    mysection->Get_material()->ComputeStress(mstrain, curvature, nonMechanicalStrain, length, statevar_old, statevar, area, width, height, random_field, mstress, mcouple);
+    double width=section->GetWidth()/2;
+    double height=section->GetHeight()/2;
+    double random_field =section->GetRandomField();
+    auto nonMechanicalStrain=section->Get_nonMechanicStrain();
+    ChVector3d mstress, mcouple;
+    section->Get_material()->ComputeStress(strain_increment, curvature_increment, nonMechanicalStrain, length, statevar_old, statevar, area, width, height, random_field, mstress, mcouple);
 
 
     ChVector3d force = area * (nmL_tr * mstress);
@@ -665,12 +643,16 @@ void ChElementCBLCON::ComputeGravityForces(ChVectorDynamic<>& Fg, const ChVector
 
 
 void ChElementCBLCON::EvaluateSectionDisplacement(const double eta, ChVector3d& u_displ, ChVector3d& u_rotaz) {
-    ChVectorDynamic<> displ(this->GetNumCoordsPosLevel());
-    this->GetStateBlock(displ);
-    ChVector3d ui = displ.segment(0,3);
-    ChVector3d ri = displ.segment(3,3);
-    ChVector3d uj = displ.segment(6,3);
-    ChVector3d rj = displ.segment(9,3);
+    // TODO JBC: had to do the hack below after redefining GetStateBlock()
+    //           Not sure what this function does, it's called by ChVisualShapeWood.
+    double angle;
+    ChVector3d axis;
+    ChVector3d ui = nodes[0]->GetPos() - nodes[0]->GetX0().GetPos();
+    (nodes[0]->GetRot() * nodes[0]->GetX0().GetRot().GetConjugate()).GetAngleAxis(angle, axis);
+    ChVector3d ri = axis * angle;
+    ChVector3d uj = nodes[1]->GetPos() - nodes[1]->GetX0().GetPos();
+    (nodes[1]->GetRot() * nodes[1]->GetX0().GetRot().GetConjugate()).GetAngleAxis(angle, axis);
+    ChVector3d rj = axis*angle;
     ChVector3d xc_xi;
     ChVector3d xc_xj;
     // For small deflection, use the initial position of the nodes and facet centers

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -145,6 +145,8 @@ void ChElementCBLCON::UpdateRotation() {
     //              This arbitrary direction is repeatable, that is the only thing that guarantee this works, otherwise, the initial quaternion determined in SetupInitial() might be different
     //              Any change to the fallback behavior of ChMatrix33::SetFromAxisX() will break this code !
     //           - I believe the commented code above for beams should be used instead, together with the initial quaternion being aligned with nmL matrix, similar to the beam element
+    // TODO JBC: This quaternion update actually does not work under large displacement
+    //           If I only comment line 154 (i.e., not update old quaternion), everything runs fine
     ChVector3d mXele = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
     ChVector3d mYele =
     (nodes[0]->Frame().GetRotMat().GetAxisY() + nodes[1]->Frame().GetRotMat().GetAxisY()).GetNormalized();
@@ -153,17 +155,23 @@ void ChElementCBLCON::UpdateRotation() {
     this->A.SetFromQuaternion(q_element_ref_rot.GetConjugate() * q_element_abs_rot);
 
     // New center position
+
     // 1. Projection `P` of center `C` on the edge should remain in the same relative position along the edge
-    ChVector3d edge0 = nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos();
-    double length0sq = edge0.Length2();
-    ChVector3d xi_xc0 = section->Get_center_ref() - nodes[0]->GetX0().GetPos();
-    double relpos_xi_xp = xi_xc0.Dot(edge0) / length0sq;
+    //    For CBL, the relative position is currently always 1/2
+    ChVector3d center = 0.5 * (nodes[0]->GetPos() + nodes[1]->GetPos());
     // 2. Vector `PC` keeps the same length but rotates with the edge
-    ChQuaternion<> q_delta = q_element_abs_rot * q_element_ref_rot.GetConjugate();
-    ChVector3d xi_xp0 = relpos_xi_xp * edge0;
-    ChVector3d xp_xc0 = xi_xc0 - xi_xp0;
-    ChVector3d edge = nodes[1]->GetPos() - nodes[0]->GetPos();
-    ChVector3d center = nodes[0]->GetPos() + relpos_xi_xp * edge + q_delta.Rotate(xp_xc0);
+    //    The centroid is aligned with the nodes for several connector types:
+    //       - ConSectionType::transverse_regular_bot
+    //       - ConSectionType::transverse_regular_gen
+    //       - ConSectionType::transverse_regular_top
+    //       - TODO: test the other connectors / ask Wisdom about the geometry
+    //    For those, rotation is unnecessary
+    if (section->GetSectionType() == ChBeamSectionCBLCON::ConSectionType::longitudinal) { // TODO JBC: why is this not aligned?
+        ChQuaternion<> q_delta = q_element_abs_rot * q_element_ref_rot.GetConjugate();
+        ChVector3d xp_xc0 = section->Get_center_ref() - 0.5 * (nodes[0]->GetX0().GetPos() + nodes[1]->GetX0().GetPos());
+        center += q_delta.Rotate(xp_xc0);
+    }
+
     section->Set_center(center);
 }
 

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -168,6 +168,8 @@ void ChElementCBLCON::UpdateRotation() {
     //       - ConSectionType::radial_ray_top
     //       - TBD about tangential rays: ConSectionType::tangential_ray_bot, ConSectionType::tangential_ray_gen, ConSectionType::tangential_ray_top
     //    For those, rotation is unnecessary
+    // TODO JBC: The top/bottom connectors should have an offset
+    //           when this is changed in the CAD, the code below should include top/bottom connectors
     if (section->GetSectionType() == ChBeamSectionCBLCON::ConSectionType::longitudinal) { // TODO JBC: why is this not aligned?
         ChQuaternion<> q_delta = q_element_abs_rot * q_element_ref_rot.GetConjugate();
         ChVector3d xp_xc0 = section->Get_center_ref() - 0.5 * (nodes[0]->GetX0().GetPos() + nodes[1]->GetX0().GetPos());

--- a/src/chrono_wood/ChElementCBLCON.cpp
+++ b/src/chrono_wood/ChElementCBLCON.cpp
@@ -32,6 +32,7 @@
 #include "chrono/core/ChMatrix33.h"
 #include "chrono/core/ChQuaternion.h"
 #include "chrono/core/ChVector3.h"
+#include "chrono_wood/ChBeamSectionCBLCON.h"
 
 namespace chrono {
 namespace wood {
@@ -125,37 +126,35 @@ void ChElementCBLCON::Update() {
 }
 
 void ChElementCBLCON::UpdateRotation() {
+    // WARNING: this code for the orientation is fragile and is only expected to work under the following conditions:
+    //  - the longitudinal direction of the CBL sample (the beams) is along the global Z direction
+    //  - the longitudinal connectors of the CBL sample are aligned in the global Z direction
+    //  - the transverse connectors of the CBL sample are located in the global XY plane
+    //  - the nodes rotational DOFs are initialized with unit quaternion, i.e., aligned with principal directions
+    // These conditions are currently met as a result of how the CAD is generated, and the `read_CBL_info` function is implemented
+    // but it is by no means general, and it might be challenged when knots in the wood are introduced and this alignment is slightly different.
+    //
+    // Under these conditions:
+    //  - the X-, or Y-axess associated to the end nodes (nodal orientation from rotational DOF / quaternion) remain orthogonal to longitudinal connectors under rigid body rotation
+    //  - the Z-axess associated to the end nodes (nodal orientation from rotational DOF / quaternion) remain orthogonal to transverse connectors
+    //
+    // The local orientation (3 direct orthogonal directions) of the connector is determined by Gram-Schmidt using:
+    //  - the node-to-node axis for the first direction
+    //  - the average Y-axis of the end nodes (valid under small torsion/bending) for the second "suggested" direction for longitudinal connectors (by convention, we could have used the average X-axis too)
+    //  - the average Z-axis of the end nodes (valid under small torsion/bending) for the second "suggested" direction for non-longitudinal connectors
     ChMatrix33<> Aabs;
-    /*
-    ChVector3d mXele_w = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
-    // propose Y_w as absolute dir of the Y axis of A node, removing the effect of Aref-to-A rotation if any:
-    //    Y_w = [R Aref->w ]*[R Aref->A ]'*{0,1,0}
-    ChVector3d myele_wA = nodes[0]->Frame().GetRot().Rotate(q_refrotA.RotateBack(ChVector3d(0, 1, 0)));
-    // propose Y_w as absolute dir of the Y axis of B node, removing the effect of Bref-to-B rotation if any:
-    //    Y_w = [R Bref->w ]*[R Bref->B ]'*{0,1,0}
-    ChVector3d myele_wB = nodes[1]->Frame().GetRot().Rotate(q_refrotB.RotateBack(ChVector3d(0, 1, 0)));
-    // Average the two Y directions to have midpoint torsion (ex -30?torsion A and +30?torsion B= 0?
-    ChVector3d myele_w = (myele_wA + myele_wB).GetNormalized();
-    Aabs.SetFromAxisX(mXele_w, myele_w);
-    q_element_abs_rot = Aabs.GetQuaternion();
-    */
-
-    // TODO JBC: This looks fragile and relies on assumptions and current behavior of other parts of the code
-    //           - If the Y-axes are aligned with the node-to-node direction, or cancel out, Gram-Schmidt will fail and use an arbitrary direction
-    //              This arbitrary direction is repeatable, that is the only thing that guarantee this works, otherwise, the initial quaternion determined in SetupInitial() might be different
-    //              Any change to the fallback behavior of ChMatrix33::SetFromAxisX() will break this code !
-    //           - I believe the commented code above for beams should be used instead, together with the initial quaternion being aligned with nmL matrix, similar to the beam element
-    // TODO JBC: This quaternion update actually does not work under large displacement
-    //           If I only comment line 154 (i.e., not update old quaternion), everything runs fine
-    ChVector3d mXele = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
-    ChVector3d mYele =
-    (nodes[0]->Frame().GetRotMat().GetAxisY() + nodes[1]->Frame().GetRotMat().GetAxisY()).GetNormalized();
-    Aabs.SetFromAxisX(mXele, mYele);
+    ChVector3d dir1 = nodes[1]->Frame().GetPos() - nodes[0]->Frame().GetPos();
+    ChVector3d dir2;
+    if (section->GetSectionType() == ChBeamSectionCBLCON::ConSectionType::longitudinal) {
+        dir2 = nodes[0]->GetRotMat().GetAxisY() + nodes[1]->GetRotMat().GetAxisY();
+    } else {
+        dir2 = nodes[0]->GetRotMat().GetAxisZ() + nodes[1]->GetRotMat().GetAxisZ();
+    }
+    Aabs.SetFromAxisX(dir1, dir2);
     q_element_abs_rot = Aabs.GetQuaternion();
     this->A.SetFromQuaternion(q_element_ref_rot.GetConjugate() * q_element_abs_rot);
 
     // New center position
-
     // 1. Projection `P` of center `C` on the edge should remain in the same relative position along the edge
     //    For CBL, the relative position is currently always 1/2
     ChVector3d center = 0.5 * (nodes[0]->GetPos() + nodes[1]->GetPos());
@@ -164,7 +163,10 @@ void ChElementCBLCON::UpdateRotation() {
     //       - ConSectionType::transverse_regular_bot
     //       - ConSectionType::transverse_regular_gen
     //       - ConSectionType::transverse_regular_top
-    //       - TODO: test the other connectors / ask Wisdom about the geometry
+    //       - ConSectionType::radial_ray_bot
+    //       - ConSectionType::radial_ray_gen
+    //       - ConSectionType::radial_ray_top
+    //       - TBD about tangential rays: ConSectionType::tangential_ray_bot, ConSectionType::tangential_ray_gen, ConSectionType::tangential_ray_top
     //    For those, rotation is unnecessary
     if (section->GetSectionType() == ChBeamSectionCBLCON::ConSectionType::longitudinal) { // TODO JBC: why is this not aligned?
         ChQuaternion<> q_delta = q_element_abs_rot * q_element_ref_rot.GetConjugate();
@@ -448,12 +450,36 @@ void ChElementCBLCON::SetupInitial(ChSystem* system) {
     this->length = (nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos()).Length();
     //this->mass = this->length * this->section->GetMassPerUnitLength();
     //this->mass = this->length * 1.0;
-    // Compute initial rotation
+
+    // Compute initial orientation
+    // WARNING: this code for the orientation is fragile and is only expected to work under the following conditions:
+    //  - the longitudinal direction of the CBL sample (the beams) is along the global Z direction
+    //  - the longitudinal connectors of the CBL sample are aligned in the global Z direction
+    //  - the transverse connectors of the CBL sample are located in the global XY plane
+    //  - the nodes rotational DOFs are initialized with unit quaternion, i.e., aligned with principal directions
+    // These conditions are currently met as a result of how the CAD is generated, and the `read_CBL_info` function is implemented
+    // but it is by no means general, and it might be challenged when knots in the wood are introduced and this alignment is slightly different.
+    //
+    // Under these conditions:
+    //  - the global X-, or Y-axis are always orthogonal to longitudinal connectors
+    //  - the global Z-axis is always orthogonal to transverse connectors
+    //
+    // The local orientation (3 direct orthogonal directions) of the connector is determined by Gram-Schmidt using:
+    //  - the node-to-node axis for the first direction
+    //  - the global Y-axis for the second "suggested" direction for longitudinal connectors (by convention, we could have used the X-axis too)
+    //  - the global Z-axis for the second "suggested" direction for non-longitudinal connectors
     ChMatrix33<> A0;
-    ChVector3d mXele = nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos();
-    ChVector3d myele =
-        (nodes[0]->GetX0().GetRotMat().GetAxisY() + nodes[1]->GetX0().GetRotMat().GetAxisY()).GetNormalized();
-    A0.SetFromAxisX(mXele, myele);
+    ChVector3d dir1(nodes[1]->GetX0().GetPos() - nodes[0]->GetX0().GetPos());
+    ChVector3d dir2;
+    if (section->GetSectionType() == ChBeamSectionCBLCON::ConSectionType::longitudinal) {
+        // We could have used directly the global Y direction ChVector3d(0, 1, 0) here,
+        // but in UpdateRotation() we find the orientation as the average of the nodes,
+        // so we us the average here as well for consistency.
+        dir2 = nodes[0]->GetX0().GetRotMat().GetAxisY() + nodes[1]->GetX0().GetRotMat().GetAxisY();
+    } else {
+        dir2 = nodes[0]->GetX0().GetRotMat().GetAxisZ() + nodes[1]->GetX0().GetRotMat().GetAxisZ();
+    }
+    A0.SetFromAxisX(dir1, dir2); // Directions are normalized inside SetFromAxisX(), no need to normalize here
     q_element_ref_rot = A0.GetQuaternion();
     q_element_abs_rot = q_element_ref_rot; // Initialize the current quaternion as the reference quaternion
 

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -133,6 +133,9 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
     /// Compute large rotation of element for corotational approach
     /// The reference frame of this Euler-Bernoulli beam has X aligned to two nodes and Y parallel to Y of 1st node
     virtual void UpdateRotation() override;
+
+    /// Compute the vectors connecting the nodes to the centroid of the section
+    void ComputeBranchVectors(ChVector3d& xi_xc, ChVector3d& xj_xc);
     //
     // The default implementation in ChElementBase is ok, but inefficient because it passes
     // through the computation of the M mass matrix via ComputeKRMmatricesGlobal(H,0,0,M).

--- a/src/chrono_wood/ChElementCBLCON.h
+++ b/src/chrono_wood/ChElementCBLCON.h
@@ -55,8 +55,11 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
     virtual unsigned int GetNumNodes() override { return 2; }
     virtual unsigned int GetNumCoordsPosLevel() override { return 2 * 6; }
     virtual unsigned int GetNodeNumCoordsPosLevel(unsigned int n) override { return 6; }
-    virtual unsigned int GetNumStateVar() override { return 1 * section->Get_material()->GetNumberOfStateVariables(); }
+    virtual unsigned int GetNumStateVar() override { return section->Get_material()->GetNumberOfStateVariables() + 2*7; } // TODO: the + 2*7 is designed to store the old DOFs (position (3) + quaternion (4)) in order to compute strain increment.
+                                                                                                                          //       This is not great, because it duplicates nodal information multiple times in each element that shares a node.
+                                                                                                                          //       Until the new FEA developments by Alessandro Tasora where nodal information is accessible, we use this hack.
 
+    unsigned int GetDOFOffset() { return section->Get_material()->GetNumberOfStateVariables(); }
     virtual std::shared_ptr<ChNodeFEAbase> GetNode(unsigned int n) override { return nodes[n]; }
 	
 	virtual std::shared_ptr<ChNodeFEAxyzrot> GetConnectorNode(unsigned int n) { return nodes[n]; }
@@ -135,12 +138,8 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
     // through the computation of the M mass matrix via ComputeKRMmatricesGlobal(H,0,0,M).
     virtual void EleIntLoadLumpedMass_Md(ChVectorDynamic<>& Md, double& error, const double c){};
     
-    /// Fills the D vector with the current field values at the nodes of the element, with proper ordering.
-    /// If the D vector has not the size of this->GetNdofs(), it will be resized.
-    /// For corotational elements, field is assumed in local reference!
-    /// Given that this element includes rotations at nodes, this gives:
-    ///  {x_a y_a z_a Rx_a Ry_a Rz_a x_b y_b z_b Rx_b Ry_b Rz_b}
-    virtual void GetStateBlock(ChVectorDynamic<>& mD) override;
+    /// Fills the last 14 entries of the state variable with the DOFs (position, quaternion) of the nodes
+    virtual void GetStateBlock(ChVectorDynamic<>& statev) override;
 
     /// Fills the Ddt vector with the current time derivatives of field values at the nodes of the element, with proper ordering.
     /// If the D vector has not the size of this->GetNdofs(), it will be resized.
@@ -153,7 +152,7 @@ class ChWoodApi ChElementCBLCON : public ChElementBeam,
 	///
 	/// Compute strain at a CBLCON facet 
 	///
-	void ComputeStrain(ChVectorN<double, 12>& displ, ChVector3d& mStrain, ChVector3d& curvature);
+	void ComputeStrainIncrement(ChVectorN<double, 12>& displ, ChVector3d& mStrain, ChVector3d& curvature);
 	///
 	///
 	///	

--- a/src/chrono_wood/ChWoodMaterialVECT.cpp
+++ b/src/chrono_wood/ChWoodMaterialVECT.cpp
@@ -49,23 +49,20 @@ ChWoodMaterialVECT::~ChWoodMaterialVECT() {}
 // statec(10): internal work
 // statec(11): crack opening
 
-void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature, ChVector3d& eigenstrain, double &len, const ChVectorDynamic<>& statev_old, ChVectorDynamic<>& statev_new,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
-    	ChVector3d mstrain;
-    	ChVector3d mcurvature;
-
-        ChVector3d dmstrain;
-    	ChVector3d dmcurvature;
-	//
+void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain_increment, ChVector3d& curvature_increment, ChVector3d& eigenstrain, double &len, const ChVectorDynamic<>& statev_old, ChVectorDynamic<>& statev_new,  double& area, double& width, double& height, double& random_field, ChVector3d& mstress, ChVector3d& mcouple) {
 	double E0=this->Get_E0();
 	double alpha=this->Get_alpha();	
 	double sigmat = this->Get_sigmat();	
 	double sigmac = this->Get_sigmac();
 	if (random_field)
 		E0=E0*random_field;
-	//std::cout<<"E0: "<<E0<<" alpha: "<<alpha<<std::endl;	
-	// 	
-	mstrain = strain.eigen() - eigenstrain.eigen();
-    dmstrain = strain - statev_old.segment(0,3); // Increment of strain over the current step so far !!! Not over the current iteration
+
+    ChVector3d strain(statev_old.segment(0,3) + strain_increment.eigen() - eigenstrain.eigen()); // TODO JBC: this is the net strain
+    // TODO JBC: LDPM stores the netstrain as a state variable. CBL only stores the strain, so we cannot compute net strain increment because the old eigenstrain is lost.
+    //           We compute the total strain increment here, not the net strain increment, until this is resolved
+    ChVector3d dstrain = strain_increment;
+    ChVector3d curvature(statev_old.segment(12,3) + curvature_increment.eigen()); // TODO: no eigencurvature ?
+    ChVector3d dcurvature = curvature_increment;
 	//	
 	//
 	double epsQ, epsQN;
@@ -73,20 +70,15 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	double h2=height*height;		
 	double w2=width*width;
 	
-	if (!this->GetCoupleMultiplier()){		
-		epsQ = std::sqrt(mstrain[0] * mstrain[0] + alpha * (mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]));
-		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]);
-		epsQN = mstrain[0];
-	}else{	
+	if (!this->GetCoupleMultiplier()) {		
+		epsQ = std::sqrt(strain[0] * strain[0] + alpha * (strain[1] * strain[1] + strain[2] * strain[2]));
+		epsT = std::sqrt(strain[1] * strain[1] + strain[2] * strain[2]);
+		epsQN = strain[0];
+	} else {	
 		double multiplier=this->GetCoupleMultiplier()/3.;
-        mcurvature = curvature; // TODO: no eigencurvature ?
-		dmcurvature = curvature - statev_old.segment(12,3); // Increment of curvature over the current step so far !!! Not over the current iteration
-				
-		epsQN = std::sqrt(mstrain[0] * mstrain[0] + multiplier*( mcurvature[1]*mcurvature[1]*w2 + mcurvature[2]*mcurvature[2]*h2));
-		epsT = std::sqrt(mstrain[1] * mstrain[1] + mstrain[2] * mstrain[2]+multiplier*mcurvature[0]*mcurvature[0]*(w2+h2));
-		
+		epsQN = std::sqrt(strain[0] * strain[0] + multiplier*( curvature[1]*curvature[1]*w2 + curvature[2]*curvature[2]*h2));
+		epsT = std::sqrt(strain[1] * strain[1] + strain[2] * strain[2]+multiplier*curvature[0]*curvature[0]*(w2+h2));
 		epsQ = std::sqrt(epsQN * epsQN + alpha * epsT * epsT);
-	
 	}
 	
 	if (statev_old(6) < epsQN) {
@@ -108,46 +100,46 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	// INELASTIC ANALYSIS
 	//
 	if (epsQ != 0) {
-		if (mstrain[0] > 10e-16 || sigmat<sigmac) {     // fracture behaivor
+		if (strain[0] > 10e-16 || sigmat<sigmac) {     // fracture behaivor
              // TODO JBC: test for sigmat<sigmac is currently debated
              //           and was not present in the eigenstrain version of that function before this refactoring
-			double strsQ = FractureBC(mstrain, random_field, len, epsQ, epsQN, epsT, statev_old, eps_max);
-			mstress[0] = strsQ * mstrain[0] / epsQ;
-			mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
-			mstress[2] = alpha * strsQ * mstrain[2] / epsQ;
+			double strsQ = FractureBC(strain, random_field, len, epsQ, epsQN, epsT, statev_old, eps_max);
+			mstress[0] = strsQ * strain[0] / epsQ;
+			mstress[1] = alpha * strsQ * strain[1] / epsQ;
+			mstress[2] = alpha * strsQ * strain[2] / epsQ;
 			//
 			if(this->GetCoupleMultiplier()){
 				double multiplier=this->GetCoupleMultiplier()/3.;
-				mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-				mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-				mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
+				mcouple[0]=multiplier*alpha*strsQ*curvature[0]*(w2+h2)/epsQ;
+				mcouple[1]=multiplier*strsQ*curvature[1]*w2/epsQ;
+				mcouple[2]=multiplier*strsQ*curvature[2]*h2/epsQ;						
 			}
 		}
 		else {
 			
-			 double strsQ = CompressBC(mstrain, random_field, len, epsQ, epsT, epsQN, statev_old);
+			 double strsQ = CompressBC(strain, random_field, len, epsQ, epsT, epsQN, statev_old);
 			 
-			 mstress[0] = strsQ * mstrain[0] / epsQ;
-			 mstress[1] = alpha * strsQ * mstrain[1] / epsQ;
-			 mstress[2] = alpha * strsQ * mstrain[2] / epsQ;
+			 mstress[0] = strsQ * strain[0] / epsQ;
+			 mstress[1] = alpha * strsQ * strain[1] / epsQ;
+			 mstress[2] = alpha * strsQ * strain[2] / epsQ;
 			 //
 			 if(this->GetCoupleMultiplier()){
 				 double multiplier=this->GetCoupleMultiplier()/3.;
-				 mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-				 mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-				 mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;						
+				 mcouple[0]=multiplier*alpha*strsQ*curvature[0]*(w2+h2)/epsQ;
+				 mcouple[1]=multiplier*strsQ*curvature[1]*w2/epsQ;
+				 mcouple[2]=multiplier*strsQ*curvature[2]*h2/epsQ;						
 			 }
 		}
-		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dmcurvature[2]);
-		double w_N = len * (mstrain[0] - mstress[0] / E0);
-		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
-		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
+		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dcurvature[2]);
+		double w_N = len * (strain[0] - mstress[0] / E0);
+		double w_M = len * (strain[1] - mstress[1] / (E0*alpha));
+		double w_L = len * (strain[2] - mstress[2] / (E0 * alpha));
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 
-		statev_new(0) = mstrain[0] + eigenstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
-		statev_new(1) = mstrain[1] + eigenstrain[1]; //           If you unload to exactly zero (like in the unit tests)
-		statev_new(2) = mstrain[2] + eigenstrain[2]; //           you go to the `else` branch and the state variables do not get updated
+		statev_new(0) = strain[0] + eigenstrain[0]; // TODO JBC: it is a bug to only update those inside this code branch.
+		statev_new(1) = strain[1] + eigenstrain[1]; //           If you unload to exactly zero (like in the unit tests)
+		statev_new(2) = strain[2] + eigenstrain[2]; //           you go to the `else` branch and the state variables do not get updated
 		statev_new(3) = mstress[0];                  //           while a loading step did happen!
 		statev_new(4) = mstress[1];                  //           I am leaving this as is for now because we will refactor this in depth soon!
 		statev_new(5) = mstress[2];                  //           The current fix aims to retrieve the "old" behavior
@@ -157,9 +149,9 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 		statev_new(11) = w;
 		//
 		if(this->GetCoupleMultiplier()){
-            statev_new(12) = mcurvature[0];
-            statev_new(13) = mcurvature[1];
-            statev_new(14) = mcurvature[2];
+            statev_new(12) = curvature[0];
+            statev_new(13) = curvature[1];
+            statev_new(14) = curvature[2];
             //
             statev_new(15) = mcouple[0];
             statev_new(16) = mcouple[1];
@@ -188,21 +180,21 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 	//
 	if (epsQ!=0) {
 	    double strsQ=E0*epsQ;
-		mstress[0]=strsQ*mstrain[0]/epsQ;
-		mstress[1]=alpha*strsQ*mstrain[1]/epsQ;
-		mstress[2]=alpha*strsQ*mstrain[2]/epsQ;		
+		mstress[0]=strsQ*strain[0]/epsQ;
+		mstress[1]=alpha*strsQ*strain[1]/epsQ;
+		mstress[2]=alpha*strsQ*strain[2]/epsQ;		
 		
 		
-		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dmstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dmstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dmstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dmcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dmcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dmcurvature[2]);
-		double w_N = len * (mstrain[0] - mstress[0] / E0);
-		double w_M = len * (mstrain[1] - mstress[1] / (E0*alpha));
-		double w_L = len * (mstrain[2] - mstress[2] / (E0 * alpha));
+		double Wint = len * area * (((mstress[0] + statev_old(3)) / 2.0) * dstrain[0] + ((mstress[1] + statev_old(4)) / 2.0) * dstrain[1] + ((mstress[2] + statev_old(5)) / 2.0) * dstrain[2] + ((mcouple[0] + statev_old(15)) / 2.0) * dcurvature[0] + ((mcouple[1] + statev_old(16)) / 2.0) * dcurvature[1] + ((mcouple[2] + statev_old(17)) / 2.0) * dcurvature[2]);
+		double w_N = len * (strain[0] - mstress[0] / E0);
+		double w_M = len * (strain[1] - mstress[1] / (E0*alpha));
+		double w_L = len * (strain[2] - mstress[2] / (E0 * alpha));
 
 		double w = std::sqrt(w_N * w_N + w_M * w_M + w_L * w_L);
 		
-		statev_new(0) = mstrain[0] + eigenstrain[0];
-		statev_new(1) = mstrain[1] + eigenstrain[1];
-		statev_new(2) = mstrain[2] + eigenstrain[2];
+		statev_new(0) = strain[0] + eigenstrain[0];
+		statev_new(1) = strain[1] + eigenstrain[1];
+		statev_new(2) = strain[2] + eigenstrain[2];
 		statev_new(3) = mstress[0];
 		statev_new(4) = mstress[1];
 		statev_new(5) = mstress[2];
@@ -214,13 +206,13 @@ void ChWoodMaterialVECT::ComputeStress(ChVector3d& strain, ChVector3d& curvature
 		
 		if(this->GetCoupleMultiplier()){
 			double multiplier=this->GetCoupleMultiplier()/3.;
-			mcouple[0]=multiplier*alpha*strsQ*mcurvature[0]*(w2+h2)/epsQ;
-			mcouple[1]=multiplier*strsQ*mcurvature[1]*w2/epsQ;
-			mcouple[2]=multiplier*strsQ*mcurvature[2]*h2/epsQ;
+			mcouple[0]=multiplier*alpha*strsQ*curvature[0]*(w2+h2)/epsQ;
+			mcouple[1]=multiplier*strsQ*curvature[1]*w2/epsQ;
+			mcouple[2]=multiplier*strsQ*curvature[2]*h2/epsQ;
 			//
-			statev_new(12) = mcurvature[0];
-			statev_new(13) = mcurvature[1];
-			statev_new(14) = mcurvature[2];
+			statev_new(12) = curvature[0];
+			statev_new(13) = curvature[1];
+			statev_new(14) = curvature[2];
 			//std::cout<<"mcurvature: "<<mcurvature.x()<<"\t"<<mcurvature.y()<<"\t"<<mcurvature.z()<<std::endl;
 			//std::cout<<"mcouple: "<<mcouple.x()<<"\t"<<mcouple.y()<<"\t"<<mcouple.z()<<std::endl;
 			//
@@ -355,7 +347,7 @@ void ChWoodMaterialVECT::ComputeStress_NEW(ChVector3d& strain_incr, ChVector3d& 
 
 
 
-double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, const ChVectorDynamic<>& statev_old, double eps_max) {
+double ChWoodMaterialVECT::FractureBC(ChVector3d& strain, double& random_field, double& len, double& epsQ, double& epsQN,  double& epsT, const ChVectorDynamic<>& statev_old, double eps_max) {
 	//
 	double E0 = this->Get_E0();
 	double alpha = this->Get_alpha();
@@ -403,7 +395,7 @@ double ChWoodMaterialVECT::FractureBC(ChVector3d& mstrain, double& random_field,
 }
 
 
-double ChWoodMaterialVECT::CompressBC(ChVector3d& mstrain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, const ChVectorDynamic<>& statev_old) {
+double ChWoodMaterialVECT::CompressBC(ChVector3d& strain, double& random_field, double& len, double& epsQ, double& epsT, double& epsQN, const ChVectorDynamic<>& statev_old) {
 	//
 	double E0 = this->Get_E0();
 	double alpha = this->Get_alpha();

--- a/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
+++ b/src/tests/unit_tests/wood/utest_WOOD_CBLCON.cpp
@@ -107,7 +107,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Translation of node A
     for (int i = 0; i<3 ; i++) {
         displ_incr(i) = disp; // X, Y, Z direction
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[i], -disp / length);
         ASSERT_DOUBLE_EQ(strain[(i+1)%3], 0.0);
         ASSERT_DOUBLE_EQ(strain[(i+2)%3], 0.0);
@@ -115,7 +115,7 @@ TEST(CBLConnectorTest, compute_strain){
     }
         // XYZ direction
         displ_incr(0) = displ_incr(1) = displ_incr(2) = disp;
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], -disp / length);
         ASSERT_DOUBLE_EQ(strain[1], -disp / length);
         ASSERT_DOUBLE_EQ(strain[2], -disp / length);
@@ -125,7 +125,7 @@ TEST(CBLConnectorTest, compute_strain){
     double dir[3][3] = {{0, 0, 0}, {0, 0, 1}, {0, -1, 0}}; // Direction of vector product: rot x (x_A - X_Center)
     for (int i = 0; i<3 ; i++) {
         displ_incr(3+i) = rot; // X, Y, Z direction
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], rot * center_from_A * dir[i][0]);
         ASSERT_DOUBLE_EQ(strain[1], rot * center_from_A * dir[i][1]);
         ASSERT_DOUBLE_EQ(strain[2], rot * center_from_A * dir[i][2]);
@@ -135,7 +135,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Translation of node B
     for (int i = 0; i<3 ; i++) {
         displ_incr(6+i) = disp; // X, Y, Z direction
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[i], disp / length);
         ASSERT_DOUBLE_EQ(strain[(i+1)%3], 0.0);
         ASSERT_DOUBLE_EQ(strain[(i+2)%3], 0.0);
@@ -143,7 +143,7 @@ TEST(CBLConnectorTest, compute_strain){
     }
         // XYZ direction
         displ_incr(6) = displ_incr(7) = displ_incr(8) = disp;
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], disp / length);
         ASSERT_DOUBLE_EQ(strain[1], disp / length);
         ASSERT_DOUBLE_EQ(strain[2], disp / length);
@@ -153,7 +153,7 @@ TEST(CBLConnectorTest, compute_strain){
     // Direction of vector product: rot x (x_B - X_Center) is the same as for node A
     for (int i = 0; i<3 ; i++) {
         displ_incr(9+i) = rot; // X, Y, Z direction
-        connector->ComputeStrain(displ_incr, strain, curvature);
+        connector->ComputeStrainIncrement(displ_incr, strain, curvature);
         ASSERT_DOUBLE_EQ(strain[0], rot * (1 - center_from_A) * dir[i][0]);
         ASSERT_DOUBLE_EQ(strain[1], rot * (1 - center_from_A) * dir[i][1]);
         ASSERT_DOUBLE_EQ(strain[2], rot * (1 - center_from_A) * dir[i][2]);


### PR DESCRIPTION
This PR implements updated Lagrangian by computing DOFs increment from the last converged DOFs and the current DOFs.
The old DOFs are stored at the end of the `statevar` vector in the element to follow our new design with updating the SV at the end of step.

Large deflection is also implemented for the connector, where the section center is updated.
Issues with the quaternion calculations were identified and a temporary solution to update the connectors quaternions is introduced (using the Z-axis for transverse quaternions, and Y-axis for the longitudinal ones). This helps, but does not solve everything.

TBD: A cleaner approach is necessary but would require an overhaul of the orientation processing, including I/O (e.g. `facetFrame` should be read and stored as the reference quaternion `q_element_ref_rot` instead, relative nodal rotation should be implemented in the `q_refrotA` and `q_refrotB` objects as opposed to the current total nodal orientation, using an update similar to the `ChElementBeamEuler`. The current quaternion could directly give the facet orientation.